### PR TITLE
[Chore] vector_store와 claude .gitignore에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,10 @@ db.sqlite3-journal
 
 # ChromaDB
 data/chroma/
+data/vector_store/
+
+# Claude Code
+.claude/
 
 # Flask stuff:
 instance/


### PR DESCRIPTION
## 어떤 변경사항인가요?

  `.gitignore`에 누락된 항목 2개를 추가했습니다.                                                                                                                        
   
  ## 작업 상세 내용                                                                                                                                                     
                  
  - [x] `data/vector_store/` 추가 — ChromaDB 벡터 저장소 경로가 누락되어 있었음
  - [x] `.claude/` 추가 — Claude Code 로컬 설정 파일이 글로벌 gitignore에만 의존하고 있었음

  ## 체크리스트

  - [x] self-test를 수행하였는가?
  - [x] 관련 문서나 주석을 업데이트하였는가?
  - [x] 설정한 코딩 컨벤션을 준수하였는가?

  ## 관련 이슈

  - 관련 이슈: 없음

  ## 리뷰 포인트

  - `data/vector_store/`가 현재는 비어있지만 추후 데이터 생성 시 실수로 커밋되는 것을 방지
  - `.claude/`는 글로벌 gitignore에만 있어 다른 기여자 환경에서 누락될 수 있는 문제 해소

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to exclude generated data files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->