### PR TITLE
[Feat] weekly plan 드릴 cross-day 중복 제거

### DIFF
--- a/src/services/agents/weekly_coach_agent.py
+++ b/src/services/agents/weekly_coach_agent.py
@@ -215,6 +215,16 @@ def retrieve_drills(state: WeeklyCoachState) -> dict:
             focus_areas,
         )
 
+    all_ids = [d["id"] for drills in day_drills.values() for d in drills]
+    if all_ids:
+        diversity = len(set(all_ids)) / len(all_ids)
+        logger.info(
+            "Drill diversity: %d unique / %d total (%.0f%%)",
+            len(set(all_ids)),
+            len(all_ids),
+            diversity * 100,
+        )
+
     return {"context": day_drills}
 
 


### PR DESCRIPTION
## 어떤 변경사항인가요?
Weekly Coach Agent의 `retrieve_drills()`에서 day별 독립 쿼리로 인한 cross-day 드릴 중복 문제를 해결합니다. `used_drill_ids` set으로 이미 배치된 드릴을 추적하고 fresh 드릴을 우선 배치하여 주간 플랜의 드릴 다양성을 높입니다.

## 작업 상세 내용

- [x] `retrieve_drills()`에 `used_drill_ids: set[str]` 추적 set 추가
- [x] day 순회를 `sorted(week_plan.keys(), key=int)`로 변경하여 day 1부터 드릴 선점
- [x] 드릴 수집 후 fresh/reused 분리 — fresh 우선 배치, 카테고리 풀 소진 시 reused graceful 허용
- [x] day 루프 후 다양성 메트릭 로깅 (unique / total, %)
- [x] 기존 테스트 통과 확인 (14/14 passed)

## 체크리스트

- [x] self-test를 수행하였는가?
- [x] 관련 문서나 주석을 업데이트하였는가?
- [x] 설정한 코딩 컨벤션을 준수하였는가?

## 관련 이슈

- 관련 이슈: #74

## 리뷰 포인트

- fresh + reused 순서로 합치는 방식이 LLM 프롬프트 활용에 적절한지
- 카테고리 풀 소진 시 reused를 허용하는 graceful 전략이 적절한지 (카테고리당 11~13개, `n_results=10`)

## 참고사항 및 스크린샷(선택)

- 수정 파일: `src/services/agents/weekly_coach_agent.py` (`retrieve_drills()` 함수만 변경)
- DB 레이어(`chroma_db.py`), 스키마(`weekly_schema.py`), LLM 프롬프트 변경 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drill selection to prevent repetitive exercises within the weekly planning cycle.
  * Enhanced drill diversity tracking across multiple days.
  * Standardized the sequence of daily drill retrieval for consistency.

* **Improvements**
  * Better logging to show fresh versus reused drill distribution and overall uniqueness metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->