### PR TITLE
[Fix] 한국어 농구 용어 매핑 테이블 확장

### DIFF
--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -40,7 +40,7 @@ SENSORY_TAG_MAP: dict[str, str] = {
 # Korean Basketball Terminology Guide (injected into prompts when language=ko)
 KO_BASKETBALL_TERMINOLOGY = """
 **한국어 농구 용어 규칙:**
-아래 용어 매핑표�� 반드시 따를 것. 표에 없는 영어 기술명은 한글 음차로 표기.
+아래 용어 매핑표를 반드시 따를 것. 표에 없는 영어 기술명은 한글 음차로 표기.
 
 | English | 한국어 |
 |---------|--------|
@@ -68,7 +68,7 @@ KO_BASKETBALL_TERMINOLOGY = """
 | pick and roll | 픽앤롤 |
 | screen | 스크린 |
 | fast break | 속공 |
-| transition | 전��� 공격 |
+| transition | 전환 공격 |
 | closeout | 클로즈아웃 |
 | defensive slide | 디펜스 슬라이드 |
 | defensive stance | 수비 자세 |
@@ -95,7 +95,7 @@ KO_BASKETBALL_TERMINOLOGY = """
 | dynamic stretching | 동적 스트레칭 |
 | static stretching | 정적 스트레칭 |
 
-- 위 표에 있는 용어는 반드시 한���어 컬럼의 표현을 사용할 것
+- 위 표에 있는 용어는 반드시 한국어 컬럼의 표현을 사용할 것
 - Reference Drills의 Drill Name이 이미 한국어로 제공된 경우 그대로 사용할 것
 """
 

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -37,6 +37,68 @@ SENSORY_TAG_MAP: dict[str, str] = {
     "value": "가성비",
 }
 
+# Korean Basketball Terminology Guide (injected into prompts when language=ko)
+KO_BASKETBALL_TERMINOLOGY = """
+**한국어 농구 용어 규칙:**
+아래 용어 매핑표�� 반드시 따를 것. 표에 없는 영어 기술명은 한글 음차로 표기.
+
+| English | 한국어 |
+|---------|--------|
+| free throw | 자유투 |
+| layup | 레이업 |
+| dunk | 덩크 |
+| three-pointer / three-point shot | 3점슛 |
+| mid-range shot | 미드레인지 슛 |
+| elbow (court area) | 엘보 |
+| elbow jumper | 엘보 점퍼 |
+| pull-up jumper | 풀업 점퍼 |
+| step-back | 스텝백 |
+| floater | 플로터 |
+| euro step | 유로스텝 |
+| crossover | 크로스오버 |
+| behind the back | 비하인드 더 백 |
+| between the legs | 비트윈 더 레그 |
+| in-and-out | 인앤아웃 |
+| hesitation | 헤지테이션 |
+| figure-8 | 8자 드리블 |
+| pound dribble | 파운드 드리블 |
+| weak hand / non-dominant hand | 약손 |
+| ball handling | 볼 핸들링 |
+| post up | 포스트업 |
+| pick and roll | 픽앤롤 |
+| screen | 스크린 |
+| fast break | 속공 |
+| transition | 전��� 공격 |
+| closeout | 클로즈아웃 |
+| defensive slide | 디펜스 슬라이드 |
+| defensive stance | 수비 자세 |
+| box out | 박스 아웃 |
+| rebound | 리바운드 |
+| assist | 어시스트 |
+| turnover | 턴오버 |
+| charge | 차지 |
+| follow-through | 팔로스루 |
+| release | 릴리스 |
+| arc | 슈팅 아크 |
+| form shooting | 폼 슈팅 |
+| spot-up | 스팟업 |
+| catch and shoot | 캐치 앤 슛 |
+| off-the-dribble | 드리블 슈팅 |
+| suicide sprints / shuttle run | 셔틀런 |
+| agility ladder | 사다리 스텝 |
+| lateral bound | 래터럴 바운드 |
+| box jump | 박스 점프 |
+| wall sit | 월 싯 |
+| plyometrics | 플라이오메트릭 |
+| warm-up | 워밍업 |
+| cool-down | 마무리 |
+| dynamic stretching | 동적 스트레칭 |
+| static stretching | 정적 스트레칭 |
+
+- 위 표에 있는 용어는 반드시 한���어 컬럼의 표현을 사용할 것
+- Reference Drills의 Drill Name이 이미 한국어로 제공된 경우 그대로 사용할 것
+"""
+
 # ChromaDB Collection Names
 DRILLS_COLLECTION_NAME = "basketball_drills"
 SHOES_COLLECTION_NAME = "basketball_shoes"

--- a/src/services/agents/coach_agent.py
+++ b/src/services/agents/coach_agent.py
@@ -8,6 +8,7 @@ from langchain_core.messages import BaseMessage
 from langgraph.graph import END, StateGraph
 from pydantic import BaseModel, Field, ValidationError
 
+from src.core.constants import KO_BASKETBALL_TERMINOLOGY
 from src.models.skill_schema import Step
 from src.services.rag.chroma_db import chroma_manager
 from src.utils.llm import chat_completion_with_retry
@@ -268,14 +269,7 @@ breaking down individual techniques into progressive micro-steps.
 **Language:**
 Respond in {language_name}. All string fields (skill_name, coach_message,
 step name, description, focus_point, success_criteria) must be in {language_name}.
-{"" if language != "ko" else '''
-**한국어 농구 용어 규칙:**
-- 한국 농구에서 실제로 통용되는 표현을 사용할 것
-- 영어 기술명은 한글 음차 그대로 표기 (예: crossover → 크로스오버, behind the back → 비하인드 더 백, step-back → 스텝백)
-- 번역하면 어색한 용어는 번역하지 말 것 (예: weak hand → "약손" ✓, "비우수 손" ✗)
-- figure-8 → 8자 드리블, floater → 플로터, euro step → 유로스텝
-- Reference Drills의 Drill Name이 이미 한국어로 제공된 경우 그대로 사용할 것
-'''}
+{"" if language != "ko" else KO_BASKETBALL_TERMINOLOGY}
 
 **Instructions:**
 1. Break the skill into 3-5 progressive steps, ordered from simplest to

--- a/src/services/agents/coach_refine_agent.py
+++ b/src/services/agents/coach_refine_agent.py
@@ -17,6 +17,7 @@ from langchain_core.messages import BaseMessage
 from langgraph.graph import END, StateGraph
 from pydantic import ValidationError
 
+from src.core.constants import KO_BASKETBALL_TERMINOLOGY
 from src.services.agents.coach_agent import SkillBreakdownCard, retrieve_drills
 from src.utils.llm import chat_completion_with_retry
 
@@ -128,14 +129,7 @@ a skill breakdown but wants changes based on their feedback.
 
 **Language:**
 Respond in {language_name}. All string fields must be in {language_name}.
-{"" if language != "ko" else '''
-**한국어 농구 용어 규칙:**
-- 한국 농구에서 실제로 통용되는 표현을 사용할 것
-- 영어 기술명은 한글 음차 그대로 표기 (예: crossover → 크로스오버, behind the back → 비하인드 더 백, step-back → 스텝백)
-- 번역하면 어색한 용어는 번역하지 말 것 (예: weak hand → "약손" ✓, "비우수 손" ✗)
-- figure-8 → 8자 드리블, floater → 플로터, euro step → 유로스텝
-- Reference Drills의 Drill Name이 이미 한국어로 제공된 경우 그대로 사용할 것
-'''}
+{"" if language != "ko" else KO_BASKETBALL_TERMINOLOGY}
 **Instructions:**
 1. Incorporate the user's feedback into a revised skill breakdown.
 2. Preserve all parts of the previous response that are NOT affected

--- a/src/services/agents/weekly_coach_agent.py
+++ b/src/services/agents/weekly_coach_agent.py
@@ -8,6 +8,7 @@ from langchain_core.messages import BaseMessage
 from langgraph.graph import END, StateGraph
 from pydantic import ValidationError
 
+from src.core.constants import KO_BASKETBALL_TERMINOLOGY
 from src.models.weekly_schema import DailyPlan, WeeklyRoutineResponse
 from src.services.agents.coach_agent import _parse_free_text
 from src.services.rag.chroma_db import chroma_manager
@@ -295,14 +296,7 @@ Available Drills from Database:
 
 **Language:**
 Respond in {language_name}. All string fields must be written in {language_name}.
-{"" if language != "ko" else '''
-**한국어 농구 용어 규칙:**
-- 한국 농구에서 실제로 통용되는 표현을 사용할 것
-- 영어 기술명은 한글 음차 그대로 표기 (예: crossover → 크로스오버, behind the back → 비하인드 더 백, step-back → 스텝백)
-- 번역하면 어색한 용어는 번역하지 말 것 (예: weak hand → "약손" ✓, "비우수 손" ✗)
-- figure-8 → 8자 드리블, floater → 플로터, euro step → 유로스텝
-- Reference Drills의 Drill Name이 이미 한국어로 제공된 경우 그대로 사용할 것
-'''}
+{"" if language != "ko" else KO_BASKETBALL_TERMINOLOGY}
 
 **Instructions:**
 1. Create a weekly routine with {training_days} days.

--- a/src/services/agents/weekly_coach_refine_agent.py
+++ b/src/services/agents/weekly_coach_refine_agent.py
@@ -16,6 +16,7 @@ from langchain_core.messages import BaseMessage
 from langgraph.graph import END, StateGraph
 from pydantic import ValidationError
 
+from src.core.constants import KO_BASKETBALL_TERMINOLOGY
 from src.models.weekly_schema import WeeklyRoutineResponse
 from src.services.agents.weekly_coach_agent import retrieve_drills
 from src.utils.llm import chat_completion_with_retry
@@ -150,14 +151,7 @@ training routine but wants changes based on their feedback.
 
 **Language:**
 Respond in {language_name}. All string fields must be in {language_name}.
-{"" if language != "ko" else '''
-**한국어 농구 용어 규칙:**
-- 한국 농구에서 실제로 통용되는 표현을 사용할 것
-- 영어 기술명은 한글 음차 그대로 표기 (예: crossover → 크로스오버, behind the back → 비하인드 더 백, step-back → 스텝백)
-- 번역하면 어색한 용어는 번역하지 말 것 (예: weak hand → "약손" ✓, "비우수 손" ✗)
-- figure-8 → 8자 드리블, floater → 플로터, euro step → 유로스텝
-- Reference Drills의 Drill Name이 이미 한국어로 제공된 경우 그대로 사용할 것
-'''}
+{"" if language != "ko" else KO_BASKETBALL_TERMINOLOGY}
 **Instructions:**
 1. Incorporate the user's feedback into a revised weekly routine.
 2. Preserve all parts of the previous response that are NOT affected


### PR DESCRIPTION
## 어떤 변경사항인가요?

> 한국어 루틴 생성 시 농구 용어 번역 품질을 개선합니다.
기존 인라인 가이드라인을 50+개 용어 매핑 테이블로 확장하고, 4개 에이전트에서 공통 상수로 재사용하도록 통일합니다.

## 작업 상세 내용

- [x] `KO_BASKETBALL_TERMINOLOGY` 상수에 50+개 용어 매핑 테이블 추가
- [x] `weekly_coach_agent`, `weekly_coach_refine_agent`의 인라인 가이드라인을 공통 상수로 교체

## 체크리스트

- [x] self-test를 수행하였는가?
- [ ] 관련 문서나 주석을 업데이트하였는가?
- [x] 설정한 코딩 컨벤션을 준수하였는가?

## 관련 이슈

- 관련 이슈: #80 

## 리뷰 포인트

- 용어 매핑 테이블의 한국어 표현이 실제 통용되는 표현인지 확인
- 4개 에이전트 모두 동일한 `KO_BASKETBALL_TERMINOLOGY` 상수를 사용하는지 확인

## 참고사항 및 스크린샷(선택)

**개선 전:** "프리드로우", "엘보 슛", "피겨-8"
**개선 후:** "자유투", "엘보 점퍼", "8자 드리블"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized Korean basketball terminology and related instructions into a single shared source to ensure consistent Korean wording across the app.
  * User-facing behavior unchanged; Korean responses now use the consolidated terminology, reducing duplication and improving consistency in translated terms and drill names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->