### PR TITLE
[Fix] 한국어 농구 용어 번역 품질 개선 및 추가 요청 반영 강화

### DIFF
--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -39,20 +39,27 @@ SENSORY_TAG_MAP: dict[str, str] = {
 
 # Korean Basketball Terminology Guide (injected into prompts when language=ko)
 KO_BASKETBALL_TERMINOLOGY = """
-**한국어 농구 용어 규칙:**
-아래 용어 매핑표를 반드시 따를 것. 표에 없는 영어 기술명은 한글 음차로 표기.
+**CRITICAL — 한국어 농구 용어 규칙 (반드시 준수):**
+아래 용어 매핑표를 반드시 따를 것. 영어를 절대 직역하지 말 것.
+(예: free throw → "프리드로우" X, "자유투" O / basket → "바구니" X, "림" O)
 
 | English | 한국어 |
 |---------|--------|
 | free throw | 자유투 |
-| layup | 레이업 |
+| layup / lay-in | 레이업 |
+| reverse layup | 리버스 레이업 |
+| finger roll | 핑거롤 |
 | dunk | 덩크 |
 | three-pointer / three-point shot | 3점슛 |
 | mid-range shot | 미드레인지 슛 |
+| bank shot | 뱅크 슛 |
+| hook shot | 훅 슛 |
+| tip-in | 팁인 |
+| alley-oop | 앨리웁 |
 | elbow (court area) | 엘보 |
 | elbow jumper | 엘보 점퍼 |
 | pull-up jumper | 풀업 점퍼 |
-| step-back | 스텝백 |
+| step-back / retreat | 스텝백 |
 | floater | 플로터 |
 | euro step | 유로스텝 |
 | crossover | 크로스오버 |
@@ -61,17 +68,42 @@ KO_BASKETBALL_TERMINOLOGY = """
 | in-and-out | 인앤아웃 |
 | hesitation | 헤지테이션 |
 | figure-8 | 8자 드리블 |
+| wrap-around / ball wrap | 볼 래핑 |
 | pound dribble | 파운드 드리블 |
+| power dribble | 파워 드리블 |
+| speed dribble | 스피드 드리블 |
+| retreat dribble | 리트릿 드리블 |
 | weak hand / non-dominant hand | 약손 |
 | ball handling | 볼 핸들링 |
+| triple threat | 트리플 스렛 |
+| pivot | 피벗 |
+| jab step | 잽 스텝 |
+| pump fake | 펌프 페이크 |
+| face-up | 페이스업 |
+| drop step | 드롭 스텝 |
+| up-and-under | 업앤언더 |
 | post up | 포스트업 |
 | pick and roll | 픽앤롤 |
 | screen | 스크린 |
 | fast break | 속공 |
 | transition | 전환 공격 |
+| basket / rim | 림 |
+| paint / lane | 페인트존 |
+| baseline | 베이스라인 |
+| outlet pass | 아울렛 패스 |
+| chest pass | 체스트 패스 |
+| bounce pass | 바운스 패스 |
+| overhead pass | 오버헤드 패스 |
+| no-look pass | 노룩 패스 |
 | closeout | 클로즈아웃 |
 | defensive slide | 디펜스 슬라이드 |
 | defensive stance | 수비 자세 |
+| help defense | 헬프 디펜스 |
+| man-to-man | 대인 수비 |
+| zone defense | 지역 수비 |
+| recovery step | 리커버리 스텝 |
+| steal | 스틸 |
+| block / shot block | 블록 |
 | box out | 박스 아웃 |
 | rebound | 리바운드 |
 | assist | 어시스트 |
@@ -95,7 +127,8 @@ KO_BASKETBALL_TERMINOLOGY = """
 | dynamic stretching | 동적 스트레칭 |
 | static stretching | 정적 스트레칭 |
 
-- 위 표에 있는 용어는 반드시 한국어 컬럼의 표현을 사용할 것
+- 위 표에 있는 용어는 반드시 한국어 컬럼의 표현만 사용할 것
+- 표에 없는 용어도 한국 농구에서 실제로 사용하는 표현으로 번역하고, 직역은 절대 금지
 - Reference Drills의 Drill Name이 이미 한국어로 제공된 경우 그대로 사용할 것
 """
 

--- a/src/services/agents/coach_agent.py
+++ b/src/services/agents/coach_agent.py
@@ -269,7 +269,6 @@ breaking down individual techniques into progressive micro-steps.
 **Language:**
 Respond in {language_name}. All string fields (skill_name, coach_message,
 step name, description, focus_point, success_criteria) must be in {language_name}.
-{"" if language != "ko" else KO_BASKETBALL_TERMINOLOGY}
 
 **Instructions:**
 1. Break the skill into 3-5 progressive steps, ordered from simplest to
@@ -288,7 +287,11 @@ step name, description, focus_point, success_criteria) must be in {language_name
 4. Set difficulty_level to a short phrase showing the progression range
    (e.g., "Basics → Game Speed" or "기초 → 실전").
 5. Write a motivating coach_message about mastering this specific skill.
-6. Output a JSON object strictly following this schema:
+6. If "Additional Request (raw)" is provided, actively reflect its content
+   throughout the routine — incorporate the requested elements into step
+   names, descriptions, and coach_message. Do not treat it as optional context.
+7. Output a JSON object strictly following this schema:
+{"" if language != "ko" else KO_BASKETBALL_TERMINOLOGY}
 
 ```json
 {schema_json}

--- a/src/services/agents/coach_refine_agent.py
+++ b/src/services/agents/coach_refine_agent.py
@@ -134,6 +134,9 @@ Respond in {language_name}. All string fields must be in {language_name}.
 1. Incorporate the user's feedback into a revised skill breakdown.
 2. Preserve all parts of the previous response that are NOT affected
    by the feedback. Only modify what the user explicitly requested.
+   Preserve any personalized elements or free_text customizations from
+   the user's original request unless the feedback explicitly asks to
+   change them.
 3. The sum of all step durations MUST equal exactly {available_time} minutes.
 4. Each step must have: name, duration_min, description, focus_point,
    success_criteria.

--- a/src/services/agents/coach_refine_agent.py
+++ b/src/services/agents/coach_refine_agent.py
@@ -129,7 +129,7 @@ a skill breakdown but wants changes based on their feedback.
 
 **Language:**
 Respond in {language_name}. All string fields must be in {language_name}.
-{"" if language != "ko" else KO_BASKETBALL_TERMINOLOGY}
+
 **Instructions:**
 1. Incorporate the user's feedback into a revised skill breakdown.
 2. Preserve all parts of the previous response that are NOT affected
@@ -139,6 +139,7 @@ Respond in {language_name}. All string fields must be in {language_name}.
    success_criteria.
 5. Keep the progressive structure (simplest → most game-like).
 6. Output a JSON object strictly following this schema:
+{"" if language != "ko" else KO_BASKETBALL_TERMINOLOGY}
 
 ```json
 {schema_json}

--- a/src/services/agents/weekly_coach_agent.py
+++ b/src/services/agents/weekly_coach_agent.py
@@ -296,7 +296,6 @@ Available Drills from Database:
 
 **Language:**
 Respond in {language_name}. All string fields must be written in {language_name}.
-{"" if language != "ko" else KO_BASKETBALL_TERMINOLOGY}
 
 **Instructions:**
 1. Create a weekly routine with {training_days} days.
@@ -318,8 +317,12 @@ Respond in {language_name}. All string fields must be written in {language_name}
 8. Create a meaningful day_label for each day reflecting its focus (e.g., "Day 1 - Shooting Focus" or "1일차 - 슈팅 집중" in Korean).
 9. Write a weekly_title that captures the overall training theme.
 10. Write a coach_overview with strategic advice for the week (recovery tips, progression notes, motivation).
+11. If "Free Text Request" is provided, actively reflect its content throughout
+    the routine — incorporate the requested elements into drill descriptions,
+    coaching_tips, day_labels, and coach_overview. Do not treat it as optional context.
 
 **Output a JSON object strictly following this schema:**
+{"" if language != "ko" else KO_BASKETBALL_TERMINOLOGY}
 ```json
 {schema_json}
 ```

--- a/src/services/agents/weekly_coach_refine_agent.py
+++ b/src/services/agents/weekly_coach_refine_agent.py
@@ -151,7 +151,7 @@ training routine but wants changes based on their feedback.
 
 **Language:**
 Respond in {language_name}. All string fields must be in {language_name}.
-{"" if language != "ko" else KO_BASKETBALL_TERMINOLOGY}
+
 **Instructions:**
 1. Incorporate the user's feedback into a revised weekly routine.
 2. Preserve all parts of the previous response that are NOT affected
@@ -164,6 +164,7 @@ Respond in {language_name}. All string fields must be in {language_name}.
    {available_time} minutes.
 5. MINIMIZE drill repetition across days.
 6. Output a JSON object strictly following this schema:
+{"" if language != "ko" else KO_BASKETBALL_TERMINOLOGY}
 
 ```json
 {schema_json}

--- a/src/services/agents/weekly_coach_refine_agent.py
+++ b/src/services/agents/weekly_coach_refine_agent.py
@@ -156,6 +156,9 @@ Respond in {language_name}. All string fields must be in {language_name}.
 1. Incorporate the user's feedback into a revised weekly routine.
 2. Preserve all parts of the previous response that are NOT affected
    by the feedback. Only modify what the user explicitly requested.
+   Preserve any personalized elements or free_text customizations from
+   the user's original request unless the feedback explicitly asks to
+   change them.
 3. Each day must have exactly 3 phases:
    - "warmup": {warmup_min} min
    - "main": {main_min} min


### PR DESCRIPTION
## 어떤 변경사항인가요?

 > 한국어 루틴 생성 시 농구 용어 번역 품질을 개선하고, 추가 요청(free_text) 내용이 루틴에 더 적극적으로 반영되도록 프롬프트를 강화했습니다.

  ## 작업 상세 내용

  - [x] `KO_BASKETBALL_TERMINOLOGY` 용어 매핑 테이블에 30+개 누락 용어 추가 (lay-in → 레이업, wrap-around → 볼 래핑, basket/rim → 림 등)
  - [x] 프롬프트 구조 변경: 용어 규칙을 JSON 스키마 바로 위로 이동 + `CRITICAL` 강조 + 직역 금지 명시
  - [x] `coach_agent.py`, `weekly_coach_agent.py`에 free_text를 루틴 전반에 적극 반영하라는 지시 추가
  - [x] 4개 에이전트 모두 적용 (coach, coach_refine, weekly_coach, weekly_coach_refine)

  ## 체크리스트

  - [x] self-test를 수행하였는가?
  - [ ] 관련 문서나 주석을 업데이트하였는가?
  - [x] 설정한 코딩 컨벤션을 준수하였는가?

  ## 관련 이슈

  - 관련 이슈: #83

  ## 리뷰 포인트

  - 용어 규칙을 JSON 스키마 바로 위로 이동 — GPT가 JSON 출력에 집중할 때도 용어 규칙을 경시하지 않도록 의도
  - free_text 반영 지시는 generate 에이전트에만 추가, refine 에이전트는 피드백 반영이 우선이므로 제외

  ## 참고사항 및 스크린샷(선택)

  - 관련 이슈: #80 (1차 한국어 용어 개선)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Expanded Korean basketball terminology with stricter translation rules for more accurate, idiomatic coaching language.
  * Added many new English→Korean basketball term mappings (moves, defenses, passing and scoring terms).
  * Made generated routines and refinements actively incorporate and preserve user “free text” requests across step names, descriptions, and coach messages.
  * Improved application of Korean terminology to ensure more consistent output in Korean.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->