### PR TITLE
[Fix] passlib 제거 및 bcrypt 직접 사용으로 호환성 문제 해결

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "tenacity>=9.1.4",
     "sqlalchemy>=2.0",
     "python-jose[cryptography]>=3.3",
-    "passlib[bcrypt]>=1.7",
+    "bcrypt>=4.0",
     "email-validator>=2.0",
 ]
 

--- a/src/core/security.py
+++ b/src/core/security.py
@@ -15,7 +15,7 @@ def hash_password(password: str) -> str:
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     try:
         return bcrypt.checkpw(plain_password.encode(), hashed_password.encode())
-    except Exception:
+    except (ValueError, TypeError):
         return False
 
 

--- a/src/core/security.py
+++ b/src/core/security.py
@@ -2,20 +2,21 @@
 
 from datetime import datetime, timedelta, timezone
 
+import bcrypt
 from jose import JWTError, jwt
-from passlib.context import CryptContext
 
 from src.core.config import settings
 
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-
 
 def hash_password(password: str) -> str:
-    return pwd_context.hash(password)
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt(rounds=12)).decode()
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
-    return pwd_context.verify(plain_password, hashed_password)
+    try:
+        return bcrypt.checkpw(plain_password.encode(), hashed_password.encode())
+    except Exception:
+        return False
 
 
 def create_access_token(subject: str) -> str:

--- a/uv.lock
+++ b/uv.lock
@@ -44,13 +44,13 @@ name = "assist"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "bcrypt" },
     { name = "chromadb" },
     { name = "email-validator" },
     { name = "fastapi" },
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "openai" },
-    { name = "passlib", extra = ["bcrypt"] },
     { name = "pydantic-settings" },
     { name = "pypdf" },
     { name = "python-dotenv" },
@@ -73,13 +73,13 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "bcrypt", specifier = ">=4.0" },
     { name = "chromadb", specifier = "~=1.5" },
     { name = "email-validator", specifier = ">=2.0" },
     { name = "fastapi", specifier = "~=0.128" },
     { name = "langchain-core", specifier = "~=1.2" },
     { name = "langgraph", specifier = "~=1.0" },
     { name = "openai", specifier = "~=2.20" },
-    { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "pypdf", specifier = ">=5.1.0" },
     { name = "python-dotenv", specifier = "~=1.2" },
@@ -1755,20 +1755,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
-]
-
-[[package]]
-name = "passlib"
-version = "1.7.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/06/9da9ee59a67fae7761aab3ccc84fa4f3f33f125b370f1ccdb915bf967c11/passlib-1.7.4.tar.gz", hash = "sha256:defd50f72b65c5402ab2c573830a6978e5f202ad0d984793c8dde2c4152ebe04", size = 689844, upload-time = "2020-10-08T19:00:52.121Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/a4/ab6b7589382ca3df236e03faa71deac88cae040af60c071a78d254a62172/passlib-1.7.4-py2.py3-none-any.whl", hash = "sha256:aa6bca462b8d8bda89c70b382f0c298a20b5560af6cbfa2dce410c0a2fb669f1", size = 525554, upload-time = "2020-10-08T19:00:49.856Z" },
-]
-
-[package.optional-dependencies]
-bcrypt = [
-    { name = "bcrypt" },
 ]
 
 [[package]]


### PR DESCRIPTION
  ## 어떤 변경사항인가요?

 > passlib이 bcrypt 4.x 이상과 호환되지 않아 발생하는 회원가입/로그인 500 에러를 수정했습니다. passlib 의존성을 제거하고 bcrypt를 직접 사용하도록 변경했습니다.

  ## 작업 상세 내용

  - [x] `src/core/security.py` — `passlib.CryptContext` 제거, `bcrypt.hashpw` / `bcrypt.checkpw` 직접 사용으로 교체
  - [x] `pyproject.toml` — `passlib[bcrypt]>=1.7` 제거, `bcrypt>=4.0` 명시

  ## 체크리스트

  - [x] self-test를 수행하였는가?
  - [ ] 관련 문서나 주석을 업데이트하였는가?
  - [x] 설정한 코딩 컨벤션을 준수하였는가?

  ## 관련 이슈

  - 관련 이슈: #85

  ## 리뷰 포인트

  - `verify_password`에서 bcrypt 예외를 `except Exception`으로 처리 — bcrypt가 잘못된 해시 포맷 등에서 다양한 예외를 던지기 때문
  - 기존 passlib으로 생성된 해시가 있는 경우 `$2b$` prefix 포맷이 동일하므로 하위 호환 문제 없음

  ## 참고사항 및 스크린샷(선택)

  - `chromadb>=1.5`가 `bcrypt>=4.0.1`을 의존하므로 passlib 버전 다운그레이드 방식으로는 해결 불가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated password security library dependencies to a current, compatible version.
  * Refactored internal password hashing and verification implementation to align with the updated dependency. Existing user passwords remain valid and authentication workflows continue to function without interruption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->