### PR TITLE
[Feat] 훈련 달력 백엔드 구현 (Plans API)

### DIFF
--- a/src/api/v1/endpoints/plans.py
+++ b/src/api/v1/endpoints/plans.py
@@ -82,6 +82,9 @@ def complete_plan_day(
     if not plan:
         raise HTTPException(status_code=404, detail="Plan not found")
 
+    if req.day_number < 1 or req.day_number > plan.total_days:
+        raise HTTPException(status_code=422, detail="day_number out of range")
+
     completed: list[int] = list(plan.completed_days or [])
     if req.completed:
         if req.day_number not in completed:

--- a/src/api/v1/endpoints/plans.py
+++ b/src/api/v1/endpoints/plans.py
@@ -35,8 +35,8 @@ def save_plan(
 
 @router.get("/", response_model=SuccessResponse[list[SavedPlanResponse]])
 def get_plans(
-    year: int = Query(...),
-    month: int = Query(...),
+    year: int = Query(..., ge=1, le=9999),
+    month: int = Query(..., ge=1, le=12),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> SuccessResponse[list[SavedPlanResponse]]:

--- a/src/api/v1/endpoints/plans.py
+++ b/src/api/v1/endpoints/plans.py
@@ -1,0 +1,113 @@
+"""Training plan (calendar) endpoints — member only."""
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from src.api.v1.endpoints.auth import get_current_user
+from src.db.database import get_db
+from src.db.models import SavedPlan, User
+from src.models.plan_schema import CompleteDayRequest, SavedPlanResponse, SavePlanRequest
+from src.models.response_schema import SuccessResponse
+
+router = APIRouter()
+
+
+@router.post("/", response_model=SuccessResponse[SavedPlanResponse])
+def save_plan(
+    req: SavePlanRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> SuccessResponse[SavedPlanResponse]:
+    plan = SavedPlan(
+        user_id=current_user.id,
+        plan_type=req.plan_type,
+        title=req.title,
+        data=req.data,
+        start_date=req.start_date,
+        total_days=req.total_days,
+        completed_days=[],
+    )
+    db.add(plan)
+    db.commit()
+    db.refresh(plan)
+    return SuccessResponse(data=SavedPlanResponse.model_validate(plan))
+
+
+@router.get("/", response_model=SuccessResponse[list[SavedPlanResponse]])
+def get_plans(
+    year: int = Query(...),
+    month: int = Query(...),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> SuccessResponse[list[SavedPlanResponse]]:
+    from calendar import monthrange
+    from datetime import date
+
+    first_day = date(year, month, 1)
+    last_day = date(year, month, monthrange(year, month)[1])
+
+    plans = (
+        db.query(SavedPlan)
+        .filter(
+            SavedPlan.user_id == current_user.id,
+            SavedPlan.start_date <= last_day,
+        )
+        .order_by(SavedPlan.start_date)
+        .all()
+    )
+
+    # Filter: plans whose date range overlaps with the requested month
+    result = []
+    for plan in plans:
+        from datetime import timedelta
+
+        plan_end = plan.start_date + timedelta(days=plan.total_days - 1)
+        if plan_end >= first_day:
+            result.append(SavedPlanResponse.model_validate(plan))
+
+    return SuccessResponse(data=result)
+
+
+@router.patch("/{plan_id}/complete", response_model=SuccessResponse[SavedPlanResponse])
+def complete_plan_day(
+    plan_id: int,
+    req: CompleteDayRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> SuccessResponse[SavedPlanResponse]:
+    plan = db.query(SavedPlan).filter(
+        SavedPlan.id == plan_id,
+        SavedPlan.user_id == current_user.id,
+    ).first()
+    if not plan:
+        raise HTTPException(status_code=404, detail="Plan not found")
+
+    completed: list[int] = list(plan.completed_days or [])
+    if req.completed:
+        if req.day_number not in completed:
+            completed.append(req.day_number)
+    else:
+        completed = [d for d in completed if d != req.day_number]
+
+    plan.completed_days = completed
+    db.commit()
+    db.refresh(plan)
+    return SuccessResponse(data=SavedPlanResponse.model_validate(plan))
+
+
+@router.delete("/{plan_id}", response_model=SuccessResponse[None])
+def delete_plan(
+    plan_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> SuccessResponse[None]:
+    plan = db.query(SavedPlan).filter(
+        SavedPlan.id == plan_id,
+        SavedPlan.user_id == current_user.id,
+    ).first()
+    if not plan:
+        raise HTTPException(status_code=404, detail="Plan not found")
+
+    db.delete(plan)
+    db.commit()
+    return SuccessResponse(message="Plan deleted successfully.")

--- a/src/api/v1/router.py
+++ b/src/api/v1/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from src.api.v1.endpoints import auth, gear, skill, whistle
+from src.api.v1.endpoints import auth, gear, plans, skill, whistle
 
 api_router = APIRouter()
 
@@ -8,3 +8,4 @@ api_router.include_router(auth.router, prefix="/auth", tags=["Auth"])
 api_router.include_router(skill.router, prefix="/skill", tags=["Skill Lab"])
 api_router.include_router(gear.router, prefix="/gear", tags=["Gear Advisor"])
 api_router.include_router(whistle.router, prefix="/whistle", tags=["The Whistle"])
+api_router.include_router(plans.router, prefix="/plans", tags=["Plans"])

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -1,8 +1,9 @@
 """SQLAlchemy ORM models."""
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
+from typing import Any
 
-from sqlalchemy import DateTime, Integer, String
+from sqlalchemy import Date, DateTime, ForeignKey, Integer, JSON, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from src.db.database import Base
@@ -15,6 +16,25 @@ class User(Base):
     email: Mapped[str] = mapped_column(String, unique=True, index=True, nullable=False)
     hashed_password: Mapped[str] = mapped_column(String, nullable=False)
     nickname: Mapped[str] = mapped_column(String(50), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+
+class SavedPlan(Base):
+    __tablename__ = "saved_plans"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    plan_type: Mapped[str] = mapped_column(String(10), nullable=False)  # "weekly" | "skill"
+    title: Mapped[str] = mapped_column(String(200), nullable=False)
+    data: Mapped[Any] = mapped_column(JSON, nullable=False)
+    start_date: Mapped[date] = mapped_column(Date, nullable=False)
+    total_days: Mapped[int] = mapped_column(Integer, nullable=False)
+    completed_days: Mapped[Any] = mapped_column(JSON, nullable=False, default=list)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),

--- a/src/models/plan_schema.py
+++ b/src/models/plan_schema.py
@@ -3,15 +3,15 @@
 from datetime import date, datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class SavePlanRequest(BaseModel):
     plan_type: Literal["weekly", "skill"]
-    title: str
+    title: str = Field(..., min_length=1, max_length=200)
     data: dict[str, Any]
     start_date: date
-    total_days: int
+    total_days: int = Field(..., ge=1)
 
 
 class SavedPlanResponse(BaseModel):

--- a/src/models/plan_schema.py
+++ b/src/models/plan_schema.py
@@ -1,0 +1,32 @@
+"""Pydantic schemas for training plan (calendar) endpoints."""
+
+from datetime import date, datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+
+class SavePlanRequest(BaseModel):
+    plan_type: Literal["weekly", "skill"]
+    title: str
+    data: dict[str, Any]
+    start_date: date
+    total_days: int
+
+
+class SavedPlanResponse(BaseModel):
+    id: int
+    plan_type: str
+    title: str
+    data: dict[str, Any]
+    start_date: date
+    total_days: int
+    completed_days: list[int]
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class CompleteDayRequest(BaseModel):
+    day_number: int
+    completed: bool

--- a/src/models/plan_schema.py
+++ b/src/models/plan_schema.py
@@ -28,5 +28,5 @@ class SavedPlanResponse(BaseModel):
 
 
 class CompleteDayRequest(BaseModel):
-    day_number: int
+    day_number: int = Field(..., ge=1)
     completed: bool


### PR DESCRIPTION
## 어떤 변경사항인가요?                                                                                                                                             
                                                                                                                                                                        
 > Weekly Routine / Skill Lab에서 생성된 훈련 루틴을 날짜에 저장하고 완료율을 추적하는 회원 전용 Plans API 추가.                                                         
                                                                                                                                                                        
  ## 작업 상세 내용                                                                                                                                                     
                                                                                                                                                                      
  - [x] `src/db/models.py` — `SavedPlan` 모델 추가 (user_id FK, plan_type, title, data JSON, start_date, total_days, completed_days JSON)                               
  - [x] `src/models/plan_schema.py` 신규 생성 — `SavePlanRequest`, `SavedPlanResponse`, `CompleteDayRequest` 스키마                                                   
  - [x] `src/api/v1/endpoints/plans.py` 신규 생성 — CRUD 엔드포인트 (모두 `get_current_user` 보호)                                                                      
    - `POST /api/v1/plans/` — 플랜 저장                                                                                                                                 
    - `GET /api/v1/plans/?year=&month=` — 월별 플랜 목록                                                                                                                
    - `PATCH /api/v1/plans/{id}/complete` — day 완료/취소 토글                                                                                                          
    - `DELETE /api/v1/plans/{id}` — 플랜 삭제                                                                                                                           
  - [x] `src/api/v1/router.py` — plans 라우터 등록                                                                                                                      
                                                                                                                                                                        
  ## 체크리스트                                                                                                                                                         
                                                                                                                                                                        
  - [x] self-test를 수행하였는가?                                                                                                                                     
  - [ ] 관련 문서나 주석을 업데이트하였는가?
  - [x] 설정한 코딩 컨벤션을 준수하였는가?
                                                                                                                                                                        
  ## 관련 이슈
                                                                                                                                                                        
  - 관련 이슈: #89                                                                                                                                                    

  ## 리뷰 포인트

  - `completed_days`를 별도 테이블 없이 JSON 배열로 저장 — 단순성을 위해 선택                                                                                           
  - 월별 필터는 `start_date <= last_day` 로 조회 후 Python에서 end_date 범위 검사 (다월에 걸친 플랜 처리)
  - 모든 엔드포인트에서 `user_id` 일치 여부 확인 (타 유저 플랜 접근 차단)                                                                                               


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create and save personal training plans (multiple plan types) with schedule and metadata.
  * View saved plans filtered by month and year.
  * Mark individual plan days as complete/uncomplete to track progress.
  * Delete saved training plans.
  * All plan operations are restricted to the authenticated user's own plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->