### PR TITLE
[Fix] CORS allow_methods에 PATCH/DELETE 추가

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -191,7 +191,7 @@ app.add_middleware(
         "http://localhost:3000",
         "https://assist-frontend-plum.vercel.app",
     ],
-    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_methods=["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
     allow_headers=["*"],
 )
 


### PR DESCRIPTION
## 어떤 변경사항인가요?

> CORS 미들웨어의 `allow_methods`에 `PATCH`와 `DELETE`가 누락되어 Plans API의 완료 토글 및 삭제 요청이 브라우저에서 차단되던 버그를 수정합니다.

## 작업 상세 내용

- [x] `src/main.py` CORS `allow_methods`에 `PATCH`, `DELETE` 추가

## 체크리스트

- [x] self-test를 수행하였는가?
- [x] 관련 문서나 주석을 업데이트하였는가?
- [x] 설정한 코딩 컨벤션을 준수하였는가?

## 관련 이슈

- 관련 이슈: #91

## 리뷰 포인트

- `allow_methods=["*"]` 대신 명시적으로 필요한 메서드만 나열하는 방식을 유지했습니다.
- 현재 API에서 `PUT` 메서드는 사용하지 않으므로 포함하지 않았습니다.

## 참고사항 및 스크린샷(선택)

**변경 전:**
```python
allow_methods=["GET", "POST", "OPTIONS"],
```

**변경 후:**
```python
allow_methods=["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended API compatibility by enabling additional HTTP methods (PATCH and DELETE) for cross-origin requests alongside existing GET, POST, and OPTIONS methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->