### PR TITLE
[Feat] 훈련 달력 저장 시 날짜 개별 선택 기능

### DIFF
--- a/src/api/v1/endpoints/plans.py
+++ b/src/api/v1/endpoints/plans.py
@@ -23,8 +23,8 @@ def save_plan(
         plan_type=req.plan_type,
         title=req.title,
         data=req.data,
-        start_date=req.start_date,
-        total_days=req.total_days,
+        training_dates=[d.isoformat() for d in req.training_dates],
+        total_days=len(req.training_dates),
         completed_days=[],
     )
     db.add(plan)
@@ -40,29 +40,17 @@ def get_plans(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> SuccessResponse[list[SavedPlanResponse]]:
-    from calendar import monthrange
-    from datetime import date
-
-    first_day = date(year, month, 1)
-    last_day = date(year, month, monthrange(year, month)[1])
-
     plans = (
         db.query(SavedPlan)
-        .filter(
-            SavedPlan.user_id == current_user.id,
-            SavedPlan.start_date <= last_day,
-        )
-        .order_by(SavedPlan.start_date)
+        .filter(SavedPlan.user_id == current_user.id)
         .all()
     )
 
-    # Filter: plans whose date range overlaps with the requested month
+    # Filter: plans with any training_date in the requested month
+    month_prefix = f"{year:04d}-{month:02d}-"
     result = []
     for plan in plans:
-        from datetime import timedelta
-
-        plan_end = plan.start_date + timedelta(days=plan.total_days - 1)
-        if plan_end >= first_day:
+        if any(d.startswith(month_prefix) for d in (plan.training_dates or [])):
             result.append(SavedPlanResponse.model_validate(plan))
 
     return SuccessResponse(data=result)
@@ -82,7 +70,7 @@ def complete_plan_day(
     if not plan:
         raise HTTPException(status_code=404, detail="Plan not found")
 
-    if req.day_number < 1 or req.day_number > plan.total_days:
+    if req.day_number < 1 or req.day_number > len(plan.training_dates or []):
         raise HTTPException(status_code=422, detail="day_number out of range")
 
     completed: list[int] = list(plan.completed_days or [])

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -1,9 +1,9 @@
 """SQLAlchemy ORM models."""
 
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import Date, DateTime, ForeignKey, Integer, JSON, String
+from sqlalchemy import DateTime, ForeignKey, Integer, JSON, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from src.db.database import Base
@@ -32,7 +32,7 @@ class SavedPlan(Base):
     plan_type: Mapped[str] = mapped_column(String(10), nullable=False)  # "weekly" | "skill"
     title: Mapped[str] = mapped_column(String(200), nullable=False)
     data: Mapped[Any] = mapped_column(JSON, nullable=False)
-    start_date: Mapped[date] = mapped_column(Date, nullable=False)
+    training_dates: Mapped[Any] = mapped_column(JSON, nullable=False)  # ["2026-04-10", "2026-04-12", ...]
     total_days: Mapped[int] = mapped_column(Integer, nullable=False)
     completed_days: Mapped[Any] = mapped_column(JSON, nullable=False, default=list)
     created_at: Mapped[datetime] = mapped_column(

--- a/src/main.py
+++ b/src/main.py
@@ -40,6 +40,17 @@ async def lifespan(app: FastAPI):
     """
     logger.info("Application startup...")
     try:
+        # Migrate saved_plans: drop if old schema (start_date column exists)
+        from sqlalchemy import inspect, text
+        inspector = inspect(engine)
+        if "saved_plans" in inspector.get_table_names():
+            columns = [c["name"] for c in inspector.get_columns("saved_plans")]
+            if "start_date" in columns:
+                with engine.connect() as conn:
+                    conn.execute(text("DROP TABLE saved_plans"))
+                    conn.commit()
+                logger.info("Dropped old saved_plans table (start_date → training_dates migration).")
+
         # Create relational DB tables (no-op if they already exist)
         Base.metadata.create_all(bind=engine)
         logger.info("Database tables initialized.")

--- a/src/models/plan_schema.py
+++ b/src/models/plan_schema.py
@@ -3,7 +3,7 @@
 from datetime import date, datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class SavePlanRequest(BaseModel):
@@ -11,6 +11,13 @@ class SavePlanRequest(BaseModel):
     title: str = Field(..., min_length=1, max_length=200)
     data: dict[str, Any]
     training_dates: list[date] = Field(..., min_length=1)
+
+    @field_validator("training_dates")
+    @classmethod
+    def no_duplicate_dates(cls, v: list[date]) -> list[date]:
+        if len(v) != len(set(v)):
+            raise ValueError("training_dates must not contain duplicates")
+        return v
 
 
 class SavedPlanResponse(BaseModel):

--- a/src/models/plan_schema.py
+++ b/src/models/plan_schema.py
@@ -10,8 +10,7 @@ class SavePlanRequest(BaseModel):
     plan_type: Literal["weekly", "skill"]
     title: str = Field(..., min_length=1, max_length=200)
     data: dict[str, Any]
-    start_date: date
-    total_days: int = Field(..., ge=1)
+    training_dates: list[date] = Field(..., min_length=1)
 
 
 class SavedPlanResponse(BaseModel):
@@ -19,7 +18,7 @@ class SavedPlanResponse(BaseModel):
     plan_type: str
     title: str
     data: dict[str, Any]
-    start_date: date
+    training_dates: list[date]
     total_days: int
     completed_days: list[int]
     created_at: datetime


### PR DESCRIPTION
## 어떤 변경사항인가요?

> 훈련 달력 저장 시 연속 날짜 자동 배치 대신 각 day별로 날짜를 개별 선택할 수 있도록 변경합니다.

## 작업 상세 내용

- [x] `SavedPlan` 모델: `start_date` (Date) → `training_dates` (JSON, list of date strings)
- [x] `SavePlanRequest` / `SavedPlanResponse` 스키마 변경 (`training_dates: list[date]`)
- [x] `plans.py` 월 필터링 로직 변경 (`training_dates` 중 해당 월 포함 여부)
- [x] `complete_plan_day` day_number 범위 검증을 `len(training_dates)` 기준으로
- [x] startup 시 기존 `saved_plans` 테이블 자동 마이그레이션 (start_date 컬럼 감지 → drop 후 재생성)

## 체크리스트

- [x] self-test를 수행하였는가?
- [ ] 관련 문서나 주석을 업데이트하였는가?
- [x] 설정한 코딩 컨벤션을 준수하였는가?

## 관련 이슈

- 관련 이슈: #93

## 리뷰 포인트

- `training_dates`는 JSON 컬럼에 `["2026-04-10", "2026-04-12"]` 형태로 저장됩니다.
- `total_days`는 `len(training_dates)`로 자동 계산되어 저장됩니다.
- 기존 DB 마이그레이션은 startup 시 `start_date` 컬럼 존재 여부로 판단하며, 마이그레이션 완료 후에는 no-op입니다.

## 참고사항 및 스크린샷(선택)

프론트엔드(별도 레포) 변경사항:
- weekly: day별 개별 date input N개
- skill: 단일 date input → `training_dates: [date]`로 변환
- mypage: `training_dates` 직접 사용, `addDays` 유틸 제거


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plans now use explicit training dates instead of a single start date + total days.
  * Month-based plan listing now matches plans by those explicit training dates.

* **Bug Fixes**
  * Completing a plan day is validated against actual training dates.
  * Save request now rejects duplicate training dates.

* **Chores**
  * Automatic migration applied to existing saved plans on startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->