### PR TITLE
[Fix] 주간 루틴 드릴 제약 완화 및 한국어 용어 개선

### DIFF
--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -121,8 +121,9 @@ KO_BASKETBALL_TERMINOLOGY = """
 | box jump | 박스 점프 |
 | wall sit | 월 싯 |
 | plyometrics | 플라이오메트릭 |
-| warm-up | 워밍업 |
-| cool-down | 마무리 |
+| warm-up / warmup | 워밍업 |
+| cool-down / cooldown | 쿨다운 |
+| combination dribble / combo dribble | 컴비네이션 드리블 |
 | dynamic stretching | 동적 스트레칭 |
 | static stretching | 정적 스트레칭 |
 

--- a/src/models/weekly_schema.py
+++ b/src/models/weekly_schema.py
@@ -99,15 +99,6 @@ class DailyPlan(BaseModel):
         missing = required_phases - phases_present
         if missing:
             raise ValueError(f"Missing required phases: {', '.join(sorted(missing))}")
-        main_drills = [d for d in self.drills if d.phase == "main"]
-        if len(main_drills) < 3:
-            raise ValueError(
-                f"main phase must contain at least 3 distinct drills, "
-                f"got {len(main_drills)}"
-            )
-        distinct_ids = {d.drill_id for d in main_drills}
-        if len(distinct_ids) < len(main_drills):
-            raise ValueError("main phase must contain at least 3 distinct drills")
         return self
 
 

--- a/src/services/agents/coach_agent.py
+++ b/src/services/agents/coach_agent.py
@@ -202,10 +202,10 @@ step name, description, focus_point, success_criteria) must be in {language_name
 4. **Step Quality Standards (STRICTLY ENFORCE):**
    - Every step must build toward real in-game application.
      Prefer: movement-based progressions, game-speed reps, adding a defender or obstacle.
-     Avoid: purely stationary isolated reps with no game context, free throw practice
-     (unless explicitly requested), drills that train a weakness in isolation without
-     connecting to a game action (e.g., do NOT generate "weak hand free throw" —
-     instead use "weak hand drive to layup" or "weak hand finish off a screen").
+     Avoid: purely stationary isolated reps with no game context, drills that train
+     a weakness in isolation without connecting to a game action (e.g., do NOT generate
+     "weak hand free throw" — instead use "weak hand drive to layup" or
+     "weak hand finish off a screen").
    - Each step must include a concrete target or success metric
      (e.g., "8 out of 10 made", "3 sets of 45 seconds", "5 consecutive clean reps").
 5. Set difficulty_level to a short phrase showing the progression range

--- a/src/services/agents/weekly_coach_agent.py
+++ b/src/services/agents/weekly_coach_agent.py
@@ -194,16 +194,18 @@ Respond in {language_name}. All string fields must be written in {language_name}
    - description: Step-by-step execution with specific reps, sets, or distance targets (3-4 sentences minimum)
    - coaching_tip: A practical tip tailored to {skill_level} level
 7. **Drill Quality Standards (STRICTLY ENFORCE):**
-   - The "main" phase MUST contain at least 3 distinct drills.
    - Every drill must be directly applicable to real game situations.
      Prefer: movement-based drills, combination moves, game-speed reps, competitive formats.
-     Avoid: purely stationary isolated reps with no game context, free throw practice
-     (unless explicitly requested), drills that only train a weakness in isolation
-     without connecting it to a game action (e.g., do NOT generate "weak hand free throw"
-     — instead use "weak hand finishing at the rim off a drive" or "weak hand dribble
-     penetration to layup").
+     Avoid: purely stationary isolated reps with no game context, drills that only train
+     a weakness in isolation without connecting it to a game action (e.g., do NOT generate
+     "weak hand free throw" — instead use "weak hand finishing at the rim off a drive" or
+     "weak hand dribble penetration to layup").
    - Each drill must include a concrete target or success metric
      (e.g., "10 made shots", "3 sets of 30 seconds", "5 consecutive reps").
+   - Use only real, established basketball drill names. Do not invent or combine words
+     into drill names that do not exist (e.g., never generate names like "새스트랩 드리블").
+     If combining multiple moves, use standard terms like "컴비네이션 드리블" or
+     "콤보 드리블".
 8. Create a meaningful day_label for each day reflecting its focus (e.g., "Day 1 - Shooting Focus" or "1일차 - 슈팅 집중" in Korean).
 9. Write a weekly_title that captures the overall training theme.
 10. Write a coach_overview with strategic advice for the week (recovery tips, progression notes, motivation).


### PR DESCRIPTION
 ## 어떤 변경사항인가요?
                                                                                                                                                                        
>  주간 루틴 생성 품질 개선 및 한국어 번역 오류 수정.        
  메인 페이즈 3개 드릴 강제 제한 제거, 존재하지 않는 드릴명 생성 금지, 쿨다운/워밍업/컴비네이션 드리블 용어 추가.
                                              
  ## 작업 상세 내용                                                                                                                                                     
   
  - [x] `DailyPlan.validate_durations_and_phases`에서 메인 페이즈 최소 3개 드릴 제한 제거                                                                               
  - [x] `generate_weekly_routine` 프롬프트에서 3개 드릴 요건 제거
  - [x] 자유투를 avoid 목록에서 제거                                                                                                                                    
  - [x] 존재하지 않는 드릴명 생성 금지 및 컴비네이션 드리블 대체 예시 추가                                                                                              
  - [x] `KO_BASKETBALL_TERMINOLOGY` 테이블에 `cooldown → 쿨다운`, `warmup → 워밍업`, `combination dribble → 컴비네이션 드리블` 추가
                                                                                                                                                                        
  ## 체크리스트                                                                                                                                                         
                                                                                                                                                                        
  - [ ] self-test를 수행하였는가?                                                                                                                                       
  - [ ] 관련 문서나 주석을 업데이트하였는가?                                                                                                                            
  - [x] 설정한 코딩 컨벤션을 준수하였는가?                                                                                                                              
                                                                                                                                                                        
  ## 관련 이슈                            
                                                                                                                                                                        
  - 관련 이슈: #97                                                                                                                                               
                                                                                                                                                                        
  ## 리뷰 포인트                                                                                                                                                        
                                                                                                                                                                        
  - `cool-down | 마무리` → `cool-down / cooldown | 쿨다운` 변경 (기존 "마무리"에서 스포츠 앱에 더 자연스러운 "쿨다운"으로 수정)
  - 드릴명 금지 규칙에 실제 발생 예시("새스트랩 드리블") 명시하여 LLM이 같은 패턴 반복하지 않도록 유도                                                                  
                                                            
  ## 참고사항 및 스크린샷(선택)                                                                                                                                         
                                          
  변경 파일:                                                                                                                                                            
  - `src/core/constants.py`                                                                                                                                             
  - `src/models/weekly_schema.py`                                                                                                                                       
  - `src/services/agents/weekly_coach_agent.py`     