### PR TITLE
[Refactor] glossary.json 영어로 전면 재작성 및 22 → 40개 항목 확장

### DIFF
--- a/data/raw/glossary.json
+++ b/data/raw/glossary.json
@@ -1,312 +1,312 @@
 [
   {
     "id": "term_001",
-    "term": "트래블링",
+    "term": "Traveling",
     "category": "violation",
-    "definition": "볼을 소지한 상태에서 피봇 풋을 설정하지 않고 세 발자국 이상 이동하는 행위",
-    "detailed_explanation": "트래블링은 농구에서 가장 흔하게 발생하는 바이얼레이션 중 하나입니다. 드리블을 하지 않고 공을 들고 이동할 때, 한 발을 피봇 풋으로 고정하고 다른 발만 움직여야 합니다. 피봇 풋을 떼거나 세 발자국 이상 이동하면 트래블링으로 판정됩니다.",
+    "definition": "Moving three or more steps while in possession of the ball without establishing a pivot foot",
+    "detailed_explanation": "Traveling is one of the most common violations in basketball. When moving with the ball without dribbling, one foot must be fixed as the pivot foot while only the other foot moves. Lifting the pivot foot or taking three or more steps is called a traveling violation.",
     "related_rules": ["Art 25"],
     "examples": [
-      "공을 들고 세 걸음 이상 걷기",
-      "드리블 후 공을 잡고 피봇 풋을 이동하기",
-      "점프 후 착지하면서 피봇 풋을 바꾸기"
+      "Walking three or more steps while holding the ball",
+      "Moving the pivot foot after picking up a dribble",
+      "Changing the pivot foot upon landing after a jump"
     ],
-    "tags": ["바이얼레이션", "이동규칙"]
+    "tags": ["violation", "movement-rule"]
   },
   {
     "id": "term_002",
-    "term": "실린더 원칙",
+    "term": "Cylinder Principle",
     "category": "technique",
-    "definition": "선수가 코트 위에서 차지하는 가상의 수직 공간을 의미하며, 이를 침범하여 발생하는 접촉은 반칙의 기준이 된다",
-    "detailed_explanation": "실린더 원칙(Cylinder Principle)은 각 선수가 자신이 서 있는 위치를 중심으로 수직으로 형성되는 공간을 가진다는 개념입니다. 선수는 양팔을 자연스럽게 위로 뻗은 범위 내에서 움직일 권리가 있으며, 상대방이 이 공간을 침범하면 파울이 됩니다.",
+    "definition": "The imaginary vertical space a player occupies on the court; contact that invades this space is the basis for a foul call",
+    "detailed_explanation": "The Cylinder Principle states that each player has a vertical space centered on their standing position. A player has the right to move within the range of their arms naturally extended upward, and if an opponent invades this space, a foul is called.",
     "related_rules": ["Art 33"],
     "examples": [
-      "수비수가 수직으로 점프하여 슛을 막는 경우 - 합법",
-      "공격수가 수비수의 실린더를 침범하며 밀고 들어가는 경우 - 오펜스 파울",
-      "수비수가 앞으로 몸을 기울여 공격수의 실린더를 침범하는 경우 - 디펜스 파울"
+      "Defender jumping vertically to block a shot — legal",
+      "Offensive player pushing into the defender's cylinder — offensive foul",
+      "Defender leaning forward to invade the offensive player's cylinder — defensive foul"
     ],
-    "tags": ["수비원칙", "파울판정", "기술"]
+    "tags": ["defensive-principle", "foul-judgment", "technique"]
   },
   {
     "id": "term_003",
-    "term": "더블 드리블",
+    "term": "Double Dribble",
     "category": "violation",
-    "definition": "드리블을 멈춘 후 다시 드리블을 시작하거나, 양손으로 동시에 드리블하는 행위",
-    "detailed_explanation": "더블 드리블은 두 가지 상황에서 발생합니다. 첫째, 드리블을 멈춘 후(공을 잡은 후) 다시 드리블을 시작하는 경우. 둘째, 양손으로 동시에 공을 터치하며 드리블하는 경우입니다.",
+    "definition": "Resuming a dribble after stopping, or dribbling with both hands simultaneously",
+    "detailed_explanation": "Double dribble occurs in two situations. First, restarting a dribble after picking up the ball. Second, touching the ball with both hands simultaneously while dribbling.",
     "related_rules": ["Art 24"],
     "examples": [
-      "드리블 후 공을 잡고 다시 드리블 시작",
-      "양손으로 동시에 공을 터치하며 드리블",
-      "공중에서 공을 잡고 착지 후 드리블"
+      "Catching a dribble then starting a new dribble",
+      "Touching the ball with both hands simultaneously while dribbling",
+      "Catching the ball mid-air, landing, then dribbling"
     ],
-    "tags": ["바이얼레이션", "드리블규칙"]
+    "tags": ["violation", "dribbling-rule"]
   },
   {
     "id": "term_004",
-    "term": "3초 룰",
+    "term": "3-Second Rule",
     "category": "violation",
-    "definition": "공격팀 선수가 상대편 제한구역 안에 3초 이상 연속으로 머무르는 것을 금지하는 규칙",
-    "detailed_explanation": "공격수는 상대방의 페인트 존(제한구역) 안에 연속으로 3초 이상 머물 수 없습니다. 이 규칙은 공격수가 골대 근처에서 지나치게 유리한 위치를 선점하는 것을 방지하기 위해 만들어졌습니다. NBA에는 수비 3초 룰도 별도로 존재합니다.",
+    "definition": "A rule prohibiting offensive players from remaining continuously in the opponent's restricted area for more than three seconds",
+    "detailed_explanation": "An offensive player cannot remain in the opponent's paint area (restricted area) for more than three consecutive seconds. This rule prevents offensive players from gaining an overly advantageous position near the basket. The NBA also has a separate defensive 3-second rule.",
     "related_rules": ["Art 26"],
     "examples": [
-      "공격수가 페인트 존에서 3초 이상 대기",
-      "포스트업 상황에서 3초 이상 머무르기",
-      "리바운드 대기 중 3초 초과"
+      "Offensive player waiting in the paint for more than 3 seconds",
+      "Remaining in the post position for more than 3 seconds",
+      "Exceeding 3 seconds while waiting for a rebound"
     ],
-    "tags": ["바이얼레이션", "시간규칙", "제한구역"]
+    "tags": ["violation", "time-rule", "restricted-area"]
   },
   {
     "id": "term_005",
-    "term": "블로킹 파울",
+    "term": "Blocking Foul",
     "category": "foul",
-    "definition": "수비수가 합법적인 수비 위치를 확보하지 못한 상태에서 공격수의 진행을 막아 발생하는 파울",
-    "detailed_explanation": "블로킹 파울은 수비수가 공격수의 이동 경로에 제대로 자리를 잡지 못한 상태에서 접촉이 발생할 때 선언됩니다. 합법적인 수비 위치(Legal Guarding Position)를 확보하려면 공격수의 몸통 앞에 양발을 디디고 있어야 하며, 공격수가 점프나 드라이브를 시작하기 전에 위치를 잡아야 합니다.",
+    "definition": "A foul that occurs when a defender fails to establish a legal guarding position and impedes the progress of an offensive player",
+    "detailed_explanation": "A blocking foul is called when contact occurs with a defender who has not properly established a legal guarding position in the offensive player's path. To establish a legal guarding position, the defender must have both feet on the floor in front of the offensive player's torso and must be in position before the offensive player begins a jump or drive.",
     "related_rules": ["Art 33", "Art 34"],
     "examples": [
-      "드라이브 중인 공격수 앞에 뒤늦게 들어가 접촉",
-      "공격수가 이미 점프한 후 수비 위치로 이동",
-      "측면에서 접촉하며 진행 방해"
+      "Moving late into the path of a driving offensive player causing contact",
+      "Repositioning after the offensive player has already jumped",
+      "Making contact from the side to impede progress"
     ],
-    "tags": ["파울", "수비", "블로킹"]
+    "tags": ["foul", "defense", "blocking"]
   },
   {
     "id": "term_006",
-    "term": "차징 파울",
+    "term": "Charging Foul",
     "category": "foul",
-    "definition": "공격수가 합법적인 수비 위치를 확보한 수비수에게 부딪혀 발생하는 오펜스 파울",
-    "detailed_explanation": "차징은 공격수가 수비수의 실린더를 침범하며 접촉을 일으킬 때 발생하는 오펜스 파울입니다. 수비수가 미리 합법적인 수비 위치를 확보하고 있었고, 공격수가 어깨나 몸통으로 밀며 진행한 경우 선언됩니다.",
+    "definition": "An offensive foul that occurs when an offensive player runs into a defender who has established a legal guarding position",
+    "detailed_explanation": "Charging is an offensive foul that occurs when an offensive player invades a defender's cylinder and causes contact. It is called when the defender has already established a legal guarding position and the offensive player pushes forward with their shoulder or torso.",
     "related_rules": ["Art 33"],
     "examples": [
-      "수비수가 자리 잡은 상태에서 어깨로 밀며 돌파",
-      "드라이브 중 정지한 수비수에게 충돌",
-      "노 차지 존 외부에서 수비수를 밀어내기"
+      "Driving into a set defender and pushing through with the shoulder",
+      "Colliding with a stationary defender during a drive",
+      "Pushing a defender outside the no-charge zone"
     ],
-    "tags": ["파울", "공격", "차징"]
+    "tags": ["foul", "offense", "charging"]
   },
   {
     "id": "term_007",
-    "term": "골텐딩",
+    "term": "Goaltending",
     "category": "violation",
-    "definition": "슛한 공이 하강 중이거나 림 위에 있을 때 방해하는 행위",
-    "detailed_explanation": "골텐딩은 슛한 공이 최고점을 지나 하강하는 중에 이를 건드리거나, 공이 림 위에 있을 때 건드려 슛의 결과에 영향을 주는 행위입니다. 공격팀이 골텐딩을 하면 득점 무효, 수비팀이 하면 득점 인정됩니다.",
+    "definition": "Interfering with a shot while the ball is on its downward arc or resting on the rim",
+    "detailed_explanation": "Goaltending is called when a player touches a shot that has passed its apex and is descending, or touches the ball while it is on the rim, affecting the outcome of the shot. If the offensive team commits goaltending, the basket is nullified; if the defensive team commits it, the basket is awarded.",
     "related_rules": ["Art 31"],
     "examples": [
-      "하강 중인 공을 블로킹",
-      "림 위에 있는 공을 건드리기",
-      "백보드에 맞고 하강하는 공을 터치"
+      "Blocking a ball on its downward arc",
+      "Touching the ball while it is resting on the rim",
+      "Touching a ball bouncing off the backboard on its way down"
     ],
-    "tags": ["바이얼레이션", "슛방해"]
+    "tags": ["violation", "shot-interference"]
   },
   {
     "id": "term_008",
-    "term": "백코트 바이얼레이션",
+    "term": "Backcourt Violation",
     "category": "violation",
-    "definition": "공격팀이 프론트코트로 공을 가져간 후 다시 백코트로 되돌리는 행위",
-    "detailed_explanation": "공격팀이 하프라인을 넘어 프론트코트로 공을 완전히 가져간 후, 드리블이나 패스로 다시 백코트(자신의 진영)로 공을 되돌리면 바이얼레이션입니다. 단, 수비팀이 터치한 공이 백코트로 가는 것은 합법입니다.",
+    "definition": "When the offensive team returns the ball to the backcourt after it has been advanced into the frontcourt",
+    "detailed_explanation": "Once the offensive team has fully advanced the ball past the half-court line into the frontcourt, returning the ball to the backcourt by dribble or pass is a violation. However, it is legal if the ball goes to the backcourt after being touched by the defensive team.",
     "related_rules": ["Art 30"],
     "examples": [
-      "하프라인 넘은 후 드리블로 다시 백코트 진입",
-      "프론트코트에서 백코트에 있는 팀원에게 패스",
-      "공격수가 넘어지며 공이 백코트로 굴러감"
+      "Dribbling back into the backcourt after crossing half-court",
+      "Passing to a teammate in the backcourt from the frontcourt",
+      "Ball rolling into the backcourt as an offensive player falls"
     ],
-    "tags": ["바이얼레이션", "코트규칙"]
+    "tags": ["violation", "court-rule"]
   },
   {
     "id": "term_009",
-    "term": "테크니컬 파울",
+    "term": "Technical Foul",
     "category": "foul",
-    "definition": "신체 접촉 없이 스포츠맨십이나 규칙을 위반하여 받는 파울",
-    "detailed_explanation": "테크니컬 파울은 심판에게 항의, 욕설, 비신사적 행동, 과도한 타임아웃 요청 등 경기 규칙과 에티켓을 위반했을 때 선언됩니다. 상대팀에게 자유투 1개(NBA는 1개, FIBA는 상황에 따라 2개)와 볼 포제션이 주어집니다.",
+    "definition": "A foul issued for violating sportsmanship or game rules without physical contact",
+    "detailed_explanation": "A technical foul is called for protesting to referees, using profanity, unsportsmanlike behavior, excessive timeout requests, or other violations of game rules and etiquette. The opposing team is awarded one free throw (NBA) or up to two free throws (FIBA, depending on the situation) and ball possession.",
     "related_rules": ["Art 36", "Art 38"],
     "examples": [
-      "심판에게 욕설이나 과도한 항의",
-      "의도적으로 경기 지연",
-      "벤치에서 코트로 무단 진입",
-      "과도한 세리머니"
+      "Verbal abuse or excessive protest toward a referee",
+      "Intentionally delaying the game",
+      "Unauthorized entry onto the court from the bench",
+      "Excessive celebration"
     ],
-    "tags": ["파울", "테크니컬", "비신사적행위"]
+    "tags": ["foul", "technical", "unsportsmanlike-conduct"]
   },
   {
     "id": "term_010",
-    "term": "피봇 풋",
+    "term": "Pivot Foot",
     "category": "technique",
-    "definition": "드리블을 하지 않은 상태에서 공을 잡은 선수가 축으로 삼아 고정해야 하는 발",
-    "detailed_explanation": "선수가 공을 잡은 후 이동하려면 한 발을 피봇 풋(축발)으로 고정하고 다른 발만 움직여야 합니다. 피봇 풋은 회전축이 되어 360도 회전할 수 있지만, 땅에서 떼면 트래블링이 됩니다. 단, 슛이나 패스를 위해 점프할 때는 피봇 풋을 뗄 수 있습니다.",
+    "definition": "The foot that a player in possession of the ball must keep fixed as an axis when not dribbling",
+    "detailed_explanation": "After catching the ball, a player must keep one foot fixed as the pivot foot and may only move the other foot. The pivot foot serves as a rotation axis and can rotate 360 degrees, but lifting it results in a traveling violation. However, the pivot foot may be lifted when jumping to shoot or pass.",
     "related_rules": ["Art 25"],
     "examples": [
-      "공을 잡고 한 발을 축으로 회전",
-      "피봇 풋을 유지하며 패스 각도 확보",
-      "피봇 풋을 떼고 드리블 시작 (합법)",
-      "피봇 풋을 떼고 다시 디디기 (트래블링)"
+      "Rotating on one foot as an axis after catching the ball",
+      "Maintaining the pivot foot while finding a passing angle",
+      "Lifting the pivot foot to begin a dribble (legal)",
+      "Lifting the pivot foot and stepping down again (traveling)"
     ],
-    "tags": ["기술", "이동규칙", "피봇"]
+    "tags": ["technique", "movement-rule", "pivot"]
   },
   {
     "id": "term_011",
-    "term": "언스포츠맨라이크 파울",
+    "term": "Unsportsmanlike Foul",
     "category": "foul",
-    "definition": "불필요하거나 과도한 접촉을 일으키거나 스포츠맨십에 반하는 의도로 행해지는 파울",
-    "detailed_explanation": "언스포츠맨라이크 파울(Unsportsmanlike Foul)은 상대방에게 과도하거나 불필요한 신체 접촉을 가하거나, 농구의 본질과 다른 방식으로 경기를 방해하려는 의도가 있는 파울입니다. 상대팀은 자유투 2개와 볼 포제션을 얻습니다. 같은 선수가 2회 받으면 퇴장됩니다.",
+    "definition": "A foul committed with unnecessary or excessive contact or with intent contrary to sportsmanship",
+    "detailed_explanation": "An unsportsmanlike foul involves unnecessary or excessive physical contact against an opponent, or a foul intended to disrupt the game in a manner inconsistent with the spirit of basketball. The opposing team receives two free throws and ball possession. A player who receives two unsportsmanlike fouls is disqualified.",
     "related_rules": ["Art 37"],
     "examples": [
-      "공을 향하지 않고 상대 선수에게 과도한 힘으로 접촉",
-      "빠른 역습 상황을 막기 위해 의도적으로 상대를 잡아당기기",
-      "마지막 수비수를 제거하기 위한 의도적 파울"
+      "Excessive forceful contact targeting the player rather than the ball",
+      "Intentionally grabbing an opponent to stop a fast break",
+      "Deliberate foul to eliminate the last defender"
     ],
-    "tags": ["파울", "언스포츠맨라이크", "퇴장"]
+    "tags": ["foul", "unsportsmanlike", "disqualification"]
   },
   {
     "id": "term_012",
-    "term": "플래그런트 파울",
+    "term": "Flagrant Foul",
     "category": "foul",
-    "definition": "상대 선수에게 과도하거나 폭력적인 접촉을 가하는 심각한 파울 (NBA 규정)",
-    "detailed_explanation": "NBA의 플래그런트 파울(Flagrant Foul)은 두 단계로 구분됩니다. Flagrant 1은 불필요한 접촉, Flagrant 2는 불필요하고 과도한 접촉입니다. Flagrant 2는 즉시 퇴장이며 상대팀에게 자유투 2개와 볼 포제션이 주어집니다. FIBA의 언스포츠맨라이크 파울에 해당합니다.",
+    "definition": "A severe foul involving excessive or violent contact against an opponent (NBA rule)",
+    "detailed_explanation": "The NBA's Flagrant Foul is divided into two levels. Flagrant 1 involves unnecessary contact; Flagrant 2 involves unnecessary and excessive contact. Flagrant 2 results in immediate ejection, and the opposing team receives two free throws and ball possession. This corresponds to FIBA's Unsportsmanlike Foul.",
     "related_rules": ["Art 37"],
     "examples": [
-      "달리는 선수의 머리를 향해 팔꿈치를 휘두르기",
-      "레이업 중인 선수를 강하게 밀어 넘어뜨리기",
-      "의도적으로 주먹을 사용한 타격"
+      "Swinging an elbow toward a running player's head",
+      "Forcefully pushing a player attempting a layup",
+      "Intentional strike with a fist"
     ],
-    "tags": ["파울", "플래그런트", "퇴장", "NBA"]
+    "tags": ["foul", "flagrant", "disqualification", "NBA"]
   },
   {
     "id": "term_013",
-    "term": "24초 바이얼레이션",
+    "term": "24-Second Violation",
     "category": "violation",
-    "definition": "공격팀이 24초 이내에 슛을 시도하지 않아 발생하는 바이얼레이션",
-    "detailed_explanation": "공격팀은 볼을 보유한 후 24초(FIBA), NBA도 24초 이내에 슛 클락이 울리기 전에 슛을 시도해야 합니다. 슛이 림에 맞거나 들어가면 초기화됩니다. 24초가 지나면 상대팀 볼이 됩니다. 공격 리바운드 후에는 14초로 리셋됩니다(FIBA/NBA 공통).",
+    "definition": "A violation that occurs when the offensive team fails to attempt a shot within 24 seconds",
+    "detailed_explanation": "The offensive team must attempt a shot before the 24-second shot clock expires (both FIBA and NBA). The clock resets when the shot hits the rim or goes in. After the clock expires, possession is given to the opposing team. After an offensive rebound, the clock resets to 14 seconds (common to both FIBA and NBA).",
     "related_rules": ["Art 29"],
     "examples": [
-      "24초 안에 슛 시도 없이 공 소유",
-      "공격 리바운드 후 14초 이내 슛 미시도",
-      "슛이 림을 맞히지 않고 24초 경과"
+      "Holding possession without a shot attempt within 24 seconds",
+      "Failing to attempt a shot within 14 seconds after an offensive rebound",
+      "24 seconds elapsing without the shot touching the rim"
     ],
-    "tags": ["바이얼레이션", "시간규칙", "샷클락"]
+    "tags": ["violation", "time-rule", "shot-clock"]
   },
   {
     "id": "term_014",
-    "term": "8초 룰",
+    "term": "8-Second Rule",
     "category": "violation",
-    "definition": "공격팀이 백코트에서 8초 이내에 공을 프론트코트로 가져가야 하는 규칙",
-    "detailed_explanation": "공격팀은 볼을 백코트에서 소유한 시점부터 8초 이내에 프론트코트로 넘겨야 합니다. 수비팀이 공을 건드리면 카운트가 리셋됩니다. 8초 이내에 공을 프론트코트로 가져가지 못하면 상대팀 볼이 됩니다.",
+    "definition": "A rule requiring the offensive team to advance the ball from the backcourt to the frontcourt within 8 seconds",
+    "detailed_explanation": "From the moment the offensive team gains possession in the backcourt, they must advance the ball into the frontcourt within 8 seconds. The count resets if the defensive team touches the ball. Failure to advance the ball within 8 seconds results in a turnover.",
     "related_rules": ["Art 28"],
     "examples": [
-      "백코트에서 8초 이상 드리블",
-      "패스를 주고받으며 8초를 넘김",
-      "드로인 이후 8초 이내 미이동"
+      "Dribbling in the backcourt for more than 8 seconds",
+      "Exchanging passes and exceeding the 8-second limit",
+      "Failing to advance past half-court within 8 seconds after a throw-in"
     ],
-    "tags": ["바이얼레이션", "시간규칙", "백코트"]
+    "tags": ["violation", "time-rule", "backcourt"]
   },
   {
     "id": "term_015",
-    "term": "5초 룰",
+    "term": "5-Second Rule",
     "category": "violation",
-    "definition": "드로인 또는 자유투 시 5초 이내에 공을 내보내거나 슛해야 하는 규칙",
-    "detailed_explanation": "드로인(throw-in) 시 5초 이내에 공을 인바운드해야 합니다. 자유투 시에도 공을 받은 후 5초 이내에 슛을 시도해야 합니다. 밀착 수비 상황에서도 볼 소지 후 5초 이내에 패스 또는 드리블을 해야 합니다(FIBA 한정).",
+    "definition": "A rule requiring the ball to be inbounded or shot within 5 seconds on a throw-in or free throw",
+    "detailed_explanation": "On a throw-in, the ball must be inbounded within 5 seconds. On a free throw, the shot must be attempted within 5 seconds of receiving the ball. Under closely guarded situations, the ball handler must also pass or dribble within 5 seconds (FIBA only).",
     "related_rules": ["Art 17", "Art 23"],
     "examples": [
-      "사이드라인 드로인 시 5초 초과",
-      "자유투 라인에서 5초 이내 미슛",
-      "밀착 수비를 받으며 5초 이상 정지"
+      "Exceeding 5 seconds on a sideline throw-in",
+      "Failing to shoot within 5 seconds on the free throw line",
+      "Standing still for more than 5 seconds under tight defense"
     ],
-    "tags": ["바이얼레이션", "시간규칙", "드로인"]
+    "tags": ["violation", "time-rule", "throw-in"]
   },
   {
     "id": "term_016",
-    "term": "스크린 (픽)",
+    "term": "Screen (Pick)",
     "category": "technique",
-    "definition": "공격팀 선수가 몸으로 팀원의 수비수를 막아 팀원을 자유롭게 하는 합법적 플레이",
-    "detailed_explanation": "스크린(Screen, Pick)은 공격 선수가 정지 상태로 수비수의 이동 경로를 막아 팀원이 열린 공간을 만들도록 돕는 플레이입니다. 스크리너는 정지 상태여야 하며, 양발을 바닥에 디디고 있어야 합니다. 이동하거나 팔·다리로 수비수를 잡으면 불법 스크린(파울)이 됩니다.",
+    "definition": "A legal play in which an offensive player uses their body to obstruct a teammate's defender, freeing the teammate",
+    "detailed_explanation": "A screen (also called a pick) is a play in which an offensive player, while stationary, blocks a defender's path to create open space for a teammate. The screener must be stationary with both feet on the floor. Moving while screening or using arms or legs to grab the defender constitutes an illegal screen (foul).",
     "related_rules": ["Art 33"],
     "examples": [
-      "픽앤롤: 스크린 후 골대 방향으로 이동",
-      "스크리너가 이동하며 수비수를 막음 (불법 스크린)",
-      "스크리너가 팔을 벌려 수비수를 잡음 (파울)"
+      "Pick-and-roll: moving toward the basket after setting a screen",
+      "Screener moving while obstructing a defender (illegal screen)",
+      "Screener spreading arms to grab a defender (foul)"
     ],
-    "tags": ["기술", "공격", "스크린", "픽앤롤"]
+    "tags": ["technique", "offense", "screen", "pick-and-roll"]
   },
   {
     "id": "term_017",
-    "term": "홀딩",
+    "term": "Holding",
     "category": "foul",
-    "definition": "상대 선수의 신체 일부를 붙잡아 이동을 방해하는 파울",
-    "detailed_explanation": "홀딩(Holding)은 상대방의 팔, 옷, 신체를 붙잡아 자유로운 이동을 방해할 때 선언되는 개인 파울입니다. 공을 잡은 선수와 그렇지 않은 선수 모두에게 적용됩니다.",
+    "definition": "A foul in which a player grabs a part of an opponent's body to impede their movement",
+    "detailed_explanation": "Holding is a personal foul called when a player grabs an opponent's arm, clothing, or body to restrict their freedom of movement. It applies to both players with and without the ball.",
     "related_rules": ["Art 33"],
     "examples": [
-      "리바운드 경쟁 중 상대 팔을 잡아 이동 방해",
-      "속공 상황에서 상대 유니폼을 잡아 지연",
-      "포스트 플레이 중 상대 허리를 잡아당기기"
+      "Grabbing an opponent's arm during a rebound battle to impede movement",
+      "Grabbing an opponent's jersey to slow a fast break",
+      "Pulling an opponent's waist during post play"
     ],
-    "tags": ["파울", "홀딩", "개인파울"]
+    "tags": ["foul", "holding", "personal-foul"]
   },
   {
     "id": "term_018",
-    "term": "킥볼",
+    "term": "Kickball",
     "category": "violation",
-    "definition": "선수가 발이나 다리를 의도적으로 사용해 공을 차거나 막는 행위",
-    "detailed_explanation": "킥볼(Kick Ball)은 선수가 발이나 무릎 이하 다리 부분을 의도적으로 사용하여 공을 차거나 막을 때 선언됩니다. 의도성이 없는 접촉(공이 발에 우연히 닿은 경우)은 바이얼레이션으로 처리하지 않습니다.",
+    "definition": "The act of intentionally using the foot or leg to kick or block the ball",
+    "detailed_explanation": "Kickball is called when a player intentionally uses their foot or lower leg to kick or deflect the ball. Unintentional contact, such as the ball accidentally touching the foot, is not called as a violation.",
     "related_rules": ["Art 25"],
     "examples": [
-      "수비수가 드리블 공을 발로 의도적으로 차기",
-      "공이 굴러올 때 발로 막기",
-      "패스된 공을 무릎으로 튕겨내기"
+      "Defender intentionally kicking a dribbled ball",
+      "Blocking a rolling ball with the foot",
+      "Deflecting a passed ball with the knee"
     ],
-    "tags": ["바이얼레이션", "킥볼"]
+    "tags": ["violation", "kickball"]
   },
   {
     "id": "term_019",
-    "term": "프리드로 바이얼레이션",
+    "term": "Free Throw Violation",
     "category": "violation",
-    "definition": "자유투 시도 과정에서 선수들이 공간이나 절차 규정을 위반하는 행위",
-    "detailed_explanation": "자유투 시 슈터는 자유투 라인 뒤에서 슛해야 하며, 다른 선수들은 지정된 위치를 지켜야 합니다. 슛이 림에 닿기 전에 라인을 넘거나 공간을 침범하면 바이얼레이션입니다. 슈터 팀이 위반하면 자유투 무효, 수비팀이 위반하면 자유투 재시도 또는 득점 인정입니다.",
+    "definition": "A violation that occurs when players breach space or procedural rules during a free throw attempt",
+    "detailed_explanation": "On a free throw, the shooter must shoot from behind the free throw line, and other players must maintain their designated positions. Crossing the line or invading lane space before the ball touches the rim is a violation. If the shooting team violates, the free throw is nullified; if the defending team violates, the free throw is re-attempted or the basket is awarded.",
     "related_rules": ["Art 23"],
     "examples": [
-      "자유투 슛 전 라인을 밟고 진입",
-      "공이 림에 닿기 전 레인 공간 침범",
-      "자유투 슈터가 라인을 밟고 슛"
+      "Stepping on the line before releasing the free throw",
+      "Invading lane space before the ball touches the rim",
+      "Shooter stepping on the free throw line while shooting"
     ],
-    "tags": ["바이얼레이션", "자유투", "프리드로"]
+    "tags": ["violation", "free-throw"]
   },
   {
     "id": "term_020",
-    "term": "점프볼",
+    "term": "Jump Ball",
     "category": "technique",
-    "definition": "두 선수가 동시에 공을 소유하거나 특정 상황에서 경기를 재개하기 위해 심판이 공을 위로 토스하는 방식",
-    "detailed_explanation": "점프볼(Jump Ball)은 경기 시작 시와 두 선수가 동시에 공을 잡는 헬드볼(Held Ball) 상황에서 사용됩니다. FIBA는 헬드볼 시 교대 포제션(Alternating Possession) 방식을 사용하며, NBA는 헬드볼마다 점프볼을 진행합니다. 점프볼에서는 두 선수가 원 안에서 공이 최고점에 달했을 때 공을 탭해야 합니다.",
+    "definition": "A method of restarting play in which the referee tosses the ball upward between two players competing for simultaneous possession or at the start of the game",
+    "detailed_explanation": "A jump ball is used at the start of the game and in held ball situations where two players gain simultaneous possession. FIBA uses an alternating possession system for held balls, while the NBA conducts a jump ball for each held ball. In a jump ball, both players must tap the ball at its apex while remaining inside the circle.",
     "related_rules": ["Art 12"],
     "examples": [
-      "경기 시작 센터 서클 점프볼",
-      "두 선수가 동시에 공을 잡은 헬드볼",
-      "점프볼에서 원 밖으로 나가기 (바이얼레이션)"
+      "Opening tip-off at center court",
+      "Held ball: two players gaining simultaneous possession",
+      "Stepping outside the circle during a jump ball (violation)"
     ],
-    "tags": ["기술", "점프볼", "헬드볼", "교대포제션"]
+    "tags": ["technique", "jump-ball", "held-ball", "alternating-possession"]
   },
   {
     "id": "term_021",
-    "term": "핸드체킹",
+    "term": "Hand-Checking",
     "category": "foul",
-    "definition": "수비수가 손을 사용해 상대 공격수의 이동을 방해하거나 지속적으로 접촉을 유지하는 파울",
-    "detailed_explanation": "핸드체킹(Hand Checking)은 수비수가 손이나 팔로 공격수의 몸에 접촉을 유지하며 이동을 방해하는 행위입니다. NBA에서는 매우 엄격하게 적용되며, 지속적인 핸드체킹은 개인 파울로 처리됩니다. 일시적이고 가벼운 접촉은 허용될 수 있습니다.",
+    "definition": "A foul in which a defender uses their hands to impede an offensive player's movement or maintains continuous contact",
+    "detailed_explanation": "Hand-checking is when a defender maintains contact with an offensive player using their hands or arms to impede their movement. It is enforced very strictly in the NBA, and persistent hand-checking is called as a personal foul. Brief, light contact may be permitted.",
     "related_rules": ["Art 33"],
     "examples": [
-      "수비수가 손을 공격수 허리에 지속적으로 대며 이동 방해",
-      "드리블러의 팔에 손을 얹어 속도 지연",
-      "공을 소지하지 않은 선수의 이동 경로를 팔로 막기"
+      "Defender continuously placing a hand on the offensive player's hip to impede movement",
+      "Resting a hand on the dribbler's arm to slow their pace",
+      "Using an arm to block the path of a player without the ball"
     ],
-    "tags": ["파울", "수비", "핸드체킹"]
+    "tags": ["foul", "defense", "hand-checking"]
   },
   {
     "id": "term_022",
-    "term": "인텐셔널 파울",
+    "term": "Intentional Foul",
     "category": "foul",
-    "definition": "전술적 목적으로 의도적으로 상대에게 파울을 범하는 행위",
-    "detailed_explanation": "인텐셔널 파울(Intentional Foul)은 경기 종료 직전 지고 있는 팀이 시간을 멈추기 위해 의도적으로 파울을 범하는 전술입니다. FIBA에서는 이를 언스포츠맨라이크 파울과 구분하여 일반 개인 파울로 처리하며, 상대팀은 자유투 기회를 얻습니다.",
+    "definition": "The act of deliberately committing a foul against an opponent for tactical purposes",
+    "detailed_explanation": "An intentional foul is a tactic used by a losing team near the end of a game to stop the clock by deliberately fouling. In FIBA, this is treated as a regular personal foul distinct from an unsportsmanlike foul, and the opposing team receives free throw opportunities.",
     "related_rules": ["Art 33", "Art 37"],
     "examples": [
-      "경기 종료 직전 볼을 소지한 선수를 파울",
-      "속공 상황에서 의도적으로 상대를 잡아 파울",
-      "파울 아웃이 된 선수를 제외하고 전술적 파울 선택"
+      "Fouling a ball-handler just before the end of the game",
+      "Intentionally grabbing an opponent during a fast break to cause a foul",
+      "Selectively targeting players for tactical fouls, excluding fouled-out players"
     ],
-    "tags": ["파울", "전술", "인텐셔널"]
+    "tags": ["foul", "tactical", "intentional"]
   }
 ]

--- a/data/raw/glossary.json
+++ b/data/raw/glossary.json
@@ -136,7 +136,7 @@
     "examples": [
       "Rotating on one foot as an axis after catching the ball",
       "Maintaining the pivot foot while finding a passing angle",
-      "Lifting the pivot foot to begin a dribble (legal)",
+      "Starting a dribble by releasing the ball and then lifting the pivot foot (legal)",
       "Lifting the pivot foot and stepping down again (traveling)"
     ],
     "tags": ["technique", "movement-rule", "pivot"]

--- a/data/raw/glossary.json
+++ b/data/raw/glossary.json
@@ -427,7 +427,7 @@
     "category": "foul",
     "definition": "A foul committed on a player who has a clear path to the basket with no defenders between them and the basket (NBA rule)",
     "detailed_explanation": "In the NBA, a clear path foul is called when a defender fouls a player who is ahead of the defense on a fast break with no other defenders between the ball handler and the basket. The penalty is two free throws plus possession of the ball for the fouled team.",
-    "related_rules": ["Art 37"],
+    "related_rules": ["NBA Rule No. 12, Section I"],
     "examples": [
       "Defender grabs a player breaking away alone on a fast break",
       "Fouling a player in the open court with only the basket ahead of them",
@@ -525,7 +525,7 @@
     "category": "violation",
     "definition": "An NBA-specific rule that prohibits a defensive player from remaining in the lane for more than three consecutive seconds unless actively guarding an opponent",
     "detailed_explanation": "Unlike FIBA, the NBA enforces a defensive three-second rule. A defender cannot stand in the paint for more than three consecutive seconds without actively guarding a nearby offensive player. If the defender is within arm's reach of an opponent, the count stops. Violation results in a technical foul and one free throw plus possession.",
-    "related_rules": ["Art 26"],
+    "related_rules": ["NBA Rule No. 10, Section XIII"],
     "examples": [
       "Defender camping in the lane without guarding anyone for more than 3 seconds",
       "Defender steps out of the lane momentarily to reset the count — legal",

--- a/data/raw/glossary.json
+++ b/data/raw/glossary.json
@@ -308,5 +308,257 @@
       "Selectively targeting players for tactical fouls, excluding fouled-out players"
     ],
     "tags": ["foul", "tactical", "intentional"]
+  },
+  {
+    "id": "term_023",
+    "term": "Carrying / Palming",
+    "category": "violation",
+    "definition": "A dribbling violation in which the player's hand rotates under the ball, causing it to come to rest momentarily in the palm",
+    "detailed_explanation": "Carrying (also called palming) occurs when a dribbler allows the ball to rest in the palm of their hand or rotates their hand so it is under the ball, interrupting the continuous dribble motion. This gives the ball handler an unfair advantage by effectively resetting the dribble.",
+    "related_rules": ["Art 24"],
+    "examples": [
+      "Rotating the hand under the ball during a crossover dribble",
+      "Pausing the ball in the palm before continuing to dribble",
+      "Cupping the ball from below during a between-the-legs move"
+    ],
+    "tags": ["violation", "dribbling-rule", "carrying", "palming"]
+  },
+  {
+    "id": "term_024",
+    "term": "Basket Interference",
+    "category": "violation",
+    "definition": "Touching the ball, rim, net, or backboard in a way that interferes with the opportunity for a shot to score",
+    "detailed_explanation": "Basket interference is called when any player touches the ball while it is in or directly above the basket cylinder, touches the rim or net while the ball is on or within the basket, or touches the backboard while the ball is in contact with it above rim level. If the offensive team commits it, the basket is cancelled; if the defensive team commits it, the basket is awarded.",
+    "related_rules": ["Art 31"],
+    "examples": [
+      "Offensive player tapping in a ball still sitting on the rim",
+      "Defensive player reaching into the basket to bat out a ball",
+      "Player grabbing the rim while the ball passes through the net"
+    ],
+    "tags": ["violation", "shot-interference", "basket-interference"]
+  },
+  {
+    "id": "term_025",
+    "term": "No-Charge Zone (Restricted Area)",
+    "category": "technique",
+    "definition": "A semicircular area directly under the basket within which a charging foul cannot be called on a driving offensive player",
+    "detailed_explanation": "The no-charge zone (restricted area) is a semicircle with a radius of 1.25 meters (FIBA) or 4 feet (NBA) from the center of the basket. A secondary defender who establishes position inside this zone cannot draw a charging foul from an offensive player driving to the basket. The rule prevents defenders from 'taking a charge' in a dangerous area near the basket.",
+    "related_rules": ["Art 33"],
+    "examples": [
+      "Defender standing inside the restricted area — driving player contact is blocking foul, not charge",
+      "Defender with one foot outside the restricted area — charging foul possible",
+      "Primary defender (directly guarding the ball) is exempt from the restricted area rule"
+    ],
+    "tags": ["technique", "restricted-area", "charging", "no-charge-zone"]
+  },
+  {
+    "id": "term_026",
+    "term": "Bonus / Penalty Situation",
+    "category": "technique",
+    "definition": "A game state in which a team has accumulated enough team fouls that the opposing team receives free throws on every subsequent foul",
+    "detailed_explanation": "Under FIBA rules, once a team commits 4 team fouls in a quarter, each subsequent foul results in two free throws for the opponent regardless of whether the foul occurred during a shot attempt. In the NBA, the bonus begins after 5 team fouls per quarter. This rule discourages excessive fouling.",
+    "related_rules": ["Art 41"],
+    "examples": [
+      "Team commits its 5th foul in the quarter — all subsequent fouls result in free throws (NBA)",
+      "Non-shooting foul in the bonus — two free throws awarded instead of throw-in",
+      "Intentional fouling in the bonus to prevent easy baskets"
+    ],
+    "tags": ["technique", "team-foul", "bonus", "penalty-situation"]
+  },
+  {
+    "id": "term_027",
+    "term": "Reach-in Foul",
+    "category": "foul",
+    "definition": "A personal foul called when a defender extends their arm to attempt a steal and makes illegal contact with the offensive player",
+    "detailed_explanation": "A reach-in foul occurs when a defender attempts to knock the ball away from a ball handler but instead makes contact with the offensive player's arm, hand, or body. Even if the defender touches the ball, if contact is also made with the offensive player in an illegal manner, the foul is still called.",
+    "related_rules": ["Art 33"],
+    "examples": [
+      "Defender slapping the offensive player's wrist while attempting a steal",
+      "Reaching around and hitting the ball handler's arm from behind",
+      "Poking at the ball and hitting the dribbler's hand"
+    ],
+    "tags": ["foul", "defense", "reach-in", "personal-foul"]
+  },
+  {
+    "id": "term_028",
+    "term": "Over the Back Foul",
+    "category": "foul",
+    "definition": "A foul called when a player makes contact with a legally positioned opponent from behind while competing for a rebound",
+    "detailed_explanation": "An over the back foul is called when a player jumps over or leans across the back of a legally positioned opponent in order to gain rebounding position or retrieve the ball. The player who is in front and properly boxed out has the right to that space; reaching over them constitutes a personal foul.",
+    "related_rules": ["Art 33"],
+    "examples": [
+      "Taller player jumping over the back of a shorter player who boxed out legally",
+      "Leaning across an opponent's shoulders to tip a rebound",
+      "Landing on an opponent's back after jumping for a rebound"
+    ],
+    "tags": ["foul", "rebound", "over-the-back", "personal-foul"]
+  },
+  {
+    "id": "term_029",
+    "term": "Loose Ball Foul",
+    "category": "foul",
+    "definition": "A personal foul committed while neither team has possession of the ball",
+    "detailed_explanation": "A loose ball foul is called when illegal contact occurs as players scramble for a ball that no team currently controls — such as after a missed shot, a deflection, or a jump ball tap. Because neither team has possession, free throws are not automatically awarded; the penalty follows standard foul rules.",
+    "related_rules": ["Art 33"],
+    "examples": [
+      "Two players collide fighting for a deflected pass",
+      "Player pushes an opponent while chasing a loose ball after a missed shot",
+      "Contact during a scramble for a ball on the floor"
+    ],
+    "tags": ["foul", "loose-ball", "personal-foul"]
+  },
+  {
+    "id": "term_030",
+    "term": "Shooting Foul",
+    "category": "foul",
+    "definition": "A personal foul committed against a player who is in the act of shooting",
+    "detailed_explanation": "A shooting foul is called when illegal contact is made with a player who has begun their shooting motion. If the shot is missed, the shooter receives free throws equal to the value of the attempted shot (2 or 3). If the shot is made despite the foul, the basket counts and one additional free throw is awarded (and-one).",
+    "related_rules": ["Art 33", "Art 41"],
+    "examples": [
+      "Defender hits the shooter's arm on a two-point attempt — 2 free throws",
+      "Contact on a three-point shooter — 3 free throws",
+      "Foul on a layup that goes in — basket counts plus 1 free throw (and-one)"
+    ],
+    "tags": ["foul", "shooting", "free-throw", "and-one"]
+  },
+  {
+    "id": "term_031",
+    "term": "Clear Path Foul",
+    "category": "foul",
+    "definition": "A foul committed on a player who has a clear path to the basket with no defenders between them and the basket (NBA rule)",
+    "detailed_explanation": "In the NBA, a clear path foul is called when a defender fouls a player who is ahead of the defense on a fast break with no other defenders between the ball handler and the basket. The penalty is two free throws plus possession of the ball for the fouled team.",
+    "related_rules": ["Art 37"],
+    "examples": [
+      "Defender grabs a player breaking away alone on a fast break",
+      "Fouling a player in the open court with only the basket ahead of them",
+      "Tripping a player on a breakaway from behind"
+    ],
+    "tags": ["foul", "fast-break", "clear-path", "NBA"]
+  },
+  {
+    "id": "term_032",
+    "term": "Moving Screen (Illegal Screen)",
+    "category": "foul",
+    "definition": "A foul called when a screener moves or uses their body illegally to obstruct a defender",
+    "detailed_explanation": "An illegal screen (moving screen) is called when the screener is not stationary at the moment of contact, moves into the defender's path too late to allow them to stop or change direction, or uses their arms or legs to hold or trip the defender. The screener must give the defender enough space to avoid the screen.",
+    "related_rules": ["Art 33"],
+    "examples": [
+      "Screener shuffling their feet as the defender makes contact",
+      "Screener extending a hip or elbow to make contact with the defender",
+      "Setting a screen and immediately moving into the defender before they can react"
+    ],
+    "tags": ["foul", "screen", "illegal-screen", "moving-screen"]
+  },
+  {
+    "id": "term_033",
+    "term": "Out of Bounds",
+    "category": "violation",
+    "definition": "When the ball or a player in possession of the ball touches the boundary line or any area outside the court",
+    "detailed_explanation": "The ball is out of bounds when it touches a player who is out of bounds, the floor, or any object outside the boundary lines. A player is out of bounds when they touch the floor or any object outside the boundary lines. The last player to touch the ball before it goes out of bounds loses possession.",
+    "related_rules": ["Art 16"],
+    "examples": [
+      "Player catches a pass while stepping on the sideline",
+      "Ball carrier steps on the baseline while driving to the basket",
+      "Ball rolls out of bounds after deflecting off a player"
+    ],
+    "tags": ["violation", "out-of-bounds", "boundary"]
+  },
+  {
+    "id": "term_034",
+    "term": "Personal Foul",
+    "category": "foul",
+    "definition": "An illegal physical contact with an opponent that is called against an individual player",
+    "detailed_explanation": "A personal foul is the most common type of foul in basketball, involving illegal contact such as hitting, pushing, holding, charging, or blocking. Each player is allowed a limited number of personal fouls per game before being disqualified (5 in FIBA, 6 in NBA). Personal fouls also accumulate as team fouls.",
+    "related_rules": ["Art 33"],
+    "examples": [
+      "Pushing an opponent to gain rebounding position",
+      "Hitting a ball handler's arm while attempting a steal",
+      "Charging into a stationary defender"
+    ],
+    "tags": ["foul", "personal-foul", "contact"]
+  },
+  {
+    "id": "term_035",
+    "term": "Team Foul",
+    "category": "technique",
+    "definition": "The cumulative count of personal fouls committed by all players on one team within a period, used to trigger the bonus situation",
+    "detailed_explanation": "Every personal foul committed by any player on a team is counted as a team foul for that quarter (or half in some leagues). Once the team foul limit is reached (4 per quarter in FIBA, 5 per quarter in NBA), the opposing team enters the bonus and receives free throws on every subsequent non-shooting foul.",
+    "related_rules": ["Art 41"],
+    "examples": [
+      "Team reaches 5 team fouls in the first quarter — opponent is now in the bonus",
+      "Team fouls reset to zero at the start of each quarter",
+      "Intentional fouling strategy used when opponent is not yet in bonus"
+    ],
+    "tags": ["technique", "team-foul", "bonus", "penalty"]
+  },
+  {
+    "id": "term_036",
+    "term": "Foul Out (Disqualification by Fouls)",
+    "category": "technique",
+    "definition": "When a player accumulates the maximum number of personal fouls allowed and is disqualified from the rest of the game",
+    "detailed_explanation": "A player who commits 5 personal fouls (FIBA) or 6 personal fouls (NBA) is disqualified and must leave the game immediately. They may not return for the remainder of the game. The team must substitute another eligible player within a designated time.",
+    "related_rules": ["Art 37"],
+    "examples": [
+      "Player commits their 5th foul in a FIBA game — disqualified",
+      "Player commits their 6th foul in an NBA game — disqualified",
+      "Team with only 5 active players has a player foul out — technical foul issued if no substitute is available"
+    ],
+    "tags": ["technique", "foul-out", "disqualification", "personal-foul"]
+  },
+  {
+    "id": "term_037",
+    "term": "Continuation (And-One)",
+    "category": "technique",
+    "definition": "When a player is fouled during a shot attempt but completes the shot before the whistle effectively stops play, earning both the basket and a free throw",
+    "detailed_explanation": "If a player is fouled while in the act of shooting and the ball goes in, the basket counts (continuation) and the player is awarded one additional free throw. The foul is called, but because the shooting motion was already in progress and resulted in a made basket, the score is not disallowed.",
+    "related_rules": ["Art 33", "Art 41"],
+    "examples": [
+      "Player is fouled on a layup attempt, the ball goes in — basket plus 1 free throw",
+      "Player absorbs contact on a jump shot that goes in — and-one awarded",
+      "Player is fouled before beginning the shooting motion — basket does not count"
+    ],
+    "tags": ["technique", "and-one", "continuation", "shooting-foul"]
+  },
+  {
+    "id": "term_038",
+    "term": "Defensive Three Seconds",
+    "category": "violation",
+    "definition": "An NBA-specific rule that prohibits a defensive player from remaining in the lane for more than three consecutive seconds unless actively guarding an opponent",
+    "detailed_explanation": "Unlike FIBA, the NBA enforces a defensive three-second rule. A defender cannot stand in the paint for more than three consecutive seconds without actively guarding a nearby offensive player. If the defender is within arm's reach of an opponent, the count stops. Violation results in a technical foul and one free throw plus possession.",
+    "related_rules": ["Art 26"],
+    "examples": [
+      "Defender camping in the lane without guarding anyone for more than 3 seconds",
+      "Defender steps out of the lane momentarily to reset the count — legal",
+      "Defender within arm's reach of a post player — count does not apply"
+    ],
+    "tags": ["violation", "defense", "3-seconds", "NBA", "lane"]
+  },
+  {
+    "id": "term_039",
+    "term": "Delay of Game",
+    "category": "violation",
+    "definition": "Any action by a player or team that intentionally slows or stops the normal flow of the game",
+    "detailed_explanation": "Delay of game violations include touching the ball after a made basket before the inbounder can retrieve it, interfering with the throw-in, or preventing the game from resuming in a timely manner. The first offense is typically a warning; subsequent violations result in a technical foul.",
+    "related_rules": ["Art 36"],
+    "examples": [
+      "Defender tapping the ball away after a made basket to slow the fast break",
+      "Team failing to be ready to resume play after a timeout",
+      "Player intentionally knocking the ball out of bounds to stop the clock"
+    ],
+    "tags": ["violation", "delay-of-game", "technical"]
+  },
+  {
+    "id": "term_040",
+    "term": "Alternating Possession",
+    "category": "technique",
+    "definition": "A FIBA rule in which teams take turns receiving the ball on held ball situations instead of conducting a jump ball each time",
+    "detailed_explanation": "Under FIBA's alternating possession rule, after the opening tip-off, all subsequent held ball situations are resolved by awarding possession to the team whose turn it is on the possession arrow. The arrow switches after each alternating possession is used. This eliminates the need for repeated jump balls during the game.",
+    "related_rules": ["Art 12"],
+    "examples": [
+      "Two players tie up the ball — team with possession arrow gets the throw-in",
+      "Arrow points to Team A after Team B received possession from the last alternating situation",
+      "Held ball during overtime — alternating possession continues from regulation"
+    ],
+    "tags": ["technique", "alternating-possession", "held-ball", "FIBA"]
   }
 ]


### PR DESCRIPTION
 ## 어떤 변경사항인가요?                                                                                                                                               

 > `data/raw/glossary.json`의 모든 텍스트 필드를 한국어에서 영어로 전면 재작성하고, 항목 수를 22개에서 40개로 확장했습니다. ChromaDB의 다른 컬렉션(rules)과 임베딩 언어를
   통일하여 cross-lingual 검색 품질을 개선합니다.                                                                                                                       
                                                                                                                                                                        
  ## 작업 상세 내용                                                                                                                                                     
                                          
  - [x] `glossary.json` 전체 텍스트 필드 한국어 → 영어 재작성 (`term`, `definition`, `detailed_explanation`, `examples`, `tags`)                                        
  - [x] `id`, `category`, `related_rules` 등 구조적 필드는 유지                                                                                                         
  - [x] 22개 → 40개로 항목 확장 (Carrying, Basket Interference, No-Charge Zone, Bonus/Penalty, Reach-in Foul, Over the Back, Loose Ball Foul, Shooting Foul, Clear Path
  Foul, Moving Screen, Out of Bounds, Personal Foul, Team Foul, Foul Out, Continuation/And-One, Defensive Three Seconds, Delay of Game, Alternating Possession 추가)    
  - [ ] ChromaDB glossary 컬렉션 재초기화 (Issue #101 해결 후 진행 예정)
                                                                                                                                                                        
  ## 체크리스트                                                                                                                                                         
                                                                                                                                                                        
  - [ ] self-test를 수행하였는가?                                                                                                                                       
  - [x] 관련 문서나 주석을 업데이트하였는가?
  - [x] 설정한 코딩 컨벤션을 준수하였는가?                                                                                                                              
                                                                                                                                                                        
  ## 관련 이슈                            
                                                                                                                                                                        
  - 관련 이슈: #102                                                                                                                                              
  - 연관 이슈: #101 (ChromaDB 재초기화는 OpenAI 크레딧 충전 후 별도 처리)                                                                                               
                                                                                                                                                                        
  ## 리뷰 포인트                          

  - `text-embedding-3-small`은 다국어 모델이므로 한국어 쿼리로 영어 용어집을 검색하는 cross-lingual retrieval은 정상 동작합니다                                         
  - ChromaDB 재초기화 전까지는 기존 한국어 임베딩이 유지되며, 재초기화 시 새 영어 텍스트로 임베딩이 생성됩니다
                                                                                                                                                                        
  ## 참고사항 및 스크린샷(선택)                                                                                                                                         
   
  - `rules` 컬렉션은 이미 영어로 구성되어 있어, 이번 작업으로 두 컬렉션의 임베딩 언어가 통일됩니다                                                                      
  - Whistle 엔드포인트의 `related_terms` 응답 필드에서 용어집이 활용됩니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Significantly expanded the glossary with new terminology and rules, increasing the total number of available reference terms.
  * Translated all existing glossary entries from Korean to English, substantially improving accessibility and usability for the broader user community.
  * Enhanced reference materials with comprehensive definitions, detailed explanations, practical examples, and contextual categorization tags for every glossary term.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->