### PR TITLE
[Feat] The Whistle RAG 검색 품질 개선 - 키워드 추출 및 조항 인용 강화

### DIFF
--- a/scripts/eval/metrics.py
+++ b/scripts/eval/metrics.py
@@ -87,23 +87,20 @@ def constraint_pass_rate(results: List[dict]) -> dict:
 def compute_llm_judge_metrics(results: List[Dict[str, Any]]) -> dict:
     """Aggregate LLM Judge scores.
 
-    Each result dict must have 'accuracy_score', 'consistency_score',
-    and 'citation_score'.
+    Each result dict must have 'accuracy_score' and 'citation_score'.
     """
     if not results:
-        return {"accuracy": 0.0, "consistency": 0.0, "citation": 0.0}
+        return {"accuracy": 0.0, "citation": 0.0}
 
     valid_results = [r for r in results if r.get("accuracy_score") is not None]
     n = len(valid_results)
     if n == 0:
-        return {"accuracy": 0.0, "consistency": 0.0, "citation": 0.0}
+        return {"accuracy": 0.0, "citation": 0.0}
 
     total_accuracy = sum(r["accuracy_score"] for r in valid_results)
-    total_consistency = sum(r["consistency_score"] for r in valid_results)
     total_citation = sum(r["citation_score"] for r in valid_results)
 
     return {
         "accuracy": total_accuracy / n,
-        "consistency": total_consistency / n,
         "citation": total_citation / n,
     }

--- a/scripts/eval/report.py
+++ b/scripts/eval/report.py
@@ -28,7 +28,6 @@ def _gear_section(gear_data: dict) -> str:
         "### LLM Judge Metrics (RAG)",
         "",
         f"- Accuracy: {judge.get('accuracy', 0.0):.2f} / 5.0",
-        f"- Consistency: {judge.get('consistency', 0.0):.2f} / 5.0",
         f"- Data Fidelity: {judge.get('citation', 0.0):.2f} / 5.0",
         "",
         "### Case Details",
@@ -55,7 +54,7 @@ def _gear_section(gear_data: dict) -> str:
         )
 
         js = d.get("llm_judge_score", {})
-        judge_str = f"A:{js.get('accuracy_score', 0)} C:{js.get('consistency_score', 0)} Cit:{js.get('citation_score', 0)}"  # noqa: E501
+        judge_str = f"A:{js.get('accuracy_score', 0)} Cit:{js.get('citation_score', 0)}"  # noqa: E501
 
         lines.append(
             f"| {d['id']} | {d['description']} | {expected} "
@@ -84,7 +83,6 @@ def _whistle_section(whistle_data: dict) -> str:
         "### LLM Judge Metrics",
         "",
         f"- Accuracy: {judge.get('accuracy', 0.0):.2f} / 5.0",
-        f"- Consistency: {judge.get('consistency', 0.0):.2f} / 5.0",
         f"- Citation: {judge.get('citation', 0.0):.2f} / 5.0",
         "",
         "### Case Details",
@@ -104,7 +102,7 @@ def _whistle_section(whistle_data: dict) -> str:
         )
 
         js = d.get("llm_judge_score", {})
-        judge_str = f"A:{js.get('accuracy_score', 0)} C:{js.get('consistency_score', 0)} Cit:{js.get('citation_score', 0)}"  # noqa: E501
+        judge_str = f"A:{js.get('accuracy_score', 0)} Cit:{js.get('citation_score', 0)}"  # noqa: E501
 
         lines.append(
             f"| {d['id']} | {d['description']} | {d['expected_decision']} "

--- a/scripts/eval/runners/gear_runner.py
+++ b/scripts/eval/runners/gear_runner.py
@@ -147,7 +147,6 @@ def run_gear_evaluation() -> dict:
         if rag_failed:
             llm_judge_score = {
                 "accuracy_score": 0,
-                "consistency_score": 0,
                 "citation_score": 0,
                 "reasoning": "Skipped: RAG failed",
             }
@@ -178,7 +177,6 @@ def run_gear_evaluation() -> dict:
                 logger.error("LLM Judge failed for %s: %s", case_id, e)
                 llm_judge_score = {
                     "accuracy_score": 0,
-                    "consistency_score": 0,
                     "citation_score": 0,
                     "reasoning": "Error",
                 }
@@ -214,7 +212,7 @@ def run_gear_evaluation() -> dict:
             rag_predicted,
             baseline_predicted,
             expected_ids,
-            f"A:{llm_judge_score.get('accuracy_score')} C:{llm_judge_score.get('consistency_score')} Cit:{llm_judge_score.get('citation_score')}"  # noqa: E501,
+            f"A:{llm_judge_score.get('accuracy_score')} Cit:{llm_judge_score.get('citation_score')}"  # noqa: E501,
         )
 
     return {

--- a/scripts/eval/runners/judge_llm_runner.py
+++ b/scripts/eval/runners/judge_llm_runner.py
@@ -22,8 +22,7 @@ def evaluate_with_llm_judge(
 
     Criteria:
     1. 정확성 (Accuracy)
-    2. 논리 일관성 (Logical Consistency)
-    3. 규칙 인용 적절성 (Citation Appropriateness)
+    2. 규칙 인용 적절성 / 데이터 충실도 (도메인별 의미 차이)
     """
 
     prompt = prompt_template.format(
@@ -61,7 +60,6 @@ def evaluate_with_llm_judge(
         parsed = json.loads(content.strip())
         return {
             "accuracy_score": int(parsed.get("accuracy_score", 0)),
-            "consistency_score": int(parsed.get("consistency_score", 0)),
             "citation_score": int(parsed.get("citation_score", 0)),
             "reasoning": str(parsed.get("reasoning", "")),
         }
@@ -70,7 +68,6 @@ def evaluate_with_llm_judge(
         logger.error(f"Failed to parse JSON from LLM Judge: {content}")
         return {
             "accuracy_score": 0,
-            "consistency_score": 0,
             "citation_score": 0,
             "reasoning": f"JSON Parsing Error: {str(e)}",
         }
@@ -78,7 +75,6 @@ def evaluate_with_llm_judge(
         logger.error(f"LLM Judge evaluation failed: {e}")
         return {
             "accuracy_score": 0,
-            "consistency_score": 0,
             "citation_score": 0,
             "reasoning": f"API Error: {str(e)}",
         }

--- a/scripts/eval/runners/whistle_runner.py
+++ b/scripts/eval/runners/whistle_runner.py
@@ -106,7 +106,6 @@ def run_whistle_evaluation() -> dict:
         if agent_failed:
             llm_judge_score = {
                 "accuracy_score": 0,
-                "consistency_score": 0,
                 "citation_score": 0,
                 "reasoning": "Skipped: agent failed",
             }
@@ -127,7 +126,6 @@ def run_whistle_evaluation() -> dict:
                 logger.error("LLM Judge failed for %s: %s", case_id, e)
                 llm_judge_score = {
                     "accuracy_score": 0,
-                    "consistency_score": 0,
                     "citation_score": 0,
                     "reasoning": "Error",
                 }
@@ -162,7 +160,7 @@ def run_whistle_evaluation() -> dict:
             expected_decision,
             predicted_articles,
             expected_articles,
-            f"A:{llm_judge_score.get('accuracy_score')} C:{llm_judge_score.get('consistency_score')} Cit:{llm_judge_score.get('citation_score')}"  # noqa: E501,
+            f"A:{llm_judge_score.get('accuracy_score')} Cit:{llm_judge_score.get('citation_score')}"  # noqa: E501,
         )
 
     return {

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -157,19 +157,16 @@ LLM_JUDGE_WHISTLE_SYSTEM_PROMPT = (
 
 LLM_JUDGE_WHISTLE_PROMPT = (
     "다음 농구 규칙 판정 답변을 평가하고, "
-    "지정된 3가지 기준에 따라 1점부터 5점까지 채점해.\n"
+    "지정된 2가지 기준에 따라 1점부터 5점까지 채점해.\n"
     "반드시 마크다운 코드 블록 없이 순수한 JSON 형태({{...}})로만 출력해라.\n\n"
     "평가 기준:\n"
     "1. 정확성 (Accuracy): 생성된 답변이 예상 정답(판정)과 일치하며, "
     "농구 규정에 맞게 상황을 정확히 판단했는가?\n"
-    "2. 논리 일관성 (Logical Consistency): 판정의 이유를 설명하는 논리 전개가 "
-    "명확하고 모순이 없는가?\n"
-    "3. 규칙 인용 적절성 (Citation Appropriateness): 근거로 제시한 조항(Article)이 "
+    "2. 규칙 인용 적절성 (Citation Appropriateness): 근거로 제시한 조항(Article)이 "
     "주어진 상황에 적절하며 올바르게 인용되었는가?\n\n"
     "출력 형식 (오직 순수 JSON만 반환):\n"
     "{{\n"
     '  "accuracy_score": <int>,\n'
-    '  "consistency_score": <int>,\n'
     '  "citation_score": <int>,\n'
     '  "reasoning": "<string explaining the scores in Korean>"\n'
     "}}\n\n"
@@ -185,19 +182,16 @@ LLM_JUDGE_GEAR_SYSTEM_PROMPT = (
 
 LLM_JUDGE_GEAR_PROMPT = (
     "다음 농구화 추천 답변을 평가하고, "
-    "지정된 3가지 기준에 따라 1점부터 5점까지 채점해.\n"
+    "지정된 2가지 기준에 따라 1점부터 5점까지 채점해.\n"
     "반드시 마크다운 코드 블록 없이 순수한 JSON 형태({{...}})로만 출력해라.\n\n"
     "평가 기준:\n"
     "1. 정확성 (Accuracy): 추천된 신발이 사용자의 sensory preferences, player archetype, "
     "budget, position 조건에 잘 맞는가? 예상 정답(expected shoe IDs)과 비교해 판단.\n"
-    "2. 논리 일관성 (Logical Consistency): 각 신발의 추천 이유가 사용자 조건과 모순 없이 "
-    "논리적으로 설명되어 있는가?\n"
-    "3. 데이터 충실도 (Data Fidelity): 응답의 신발 정보(brand, model, price, sensory tags)가 "
+    "2. 데이터 충실도 (Data Fidelity): 응답의 신발 정보(brand, model, price, sensory tags)가 "
     "RAG로 검색된 실제 데이터를 정확히 반영했는가? 임의로 만들어낸 정보가 없는가?\n\n"
     "출력 형식 (오직 순수 JSON만 반환):\n"
     "{{\n"
     '  "accuracy_score": <int>,\n'
-    '  "consistency_score": <int>,\n'
     '  "citation_score": <int>,\n'
     '  "reasoning": "<string explaining the scores in Korean>"\n'
     "}}\n\n"

--- a/src/models/rule_schema.py
+++ b/src/models/rule_schema.py
@@ -1,6 +1,6 @@
-from typing import List, Literal, Optional
+from typing import Any, List, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class WhistleRequest(BaseModel):
@@ -34,6 +34,13 @@ class RuleReference(BaseModel):
         None, description="Page number in the rules document, if available"
     )
     excerpt: str = Field(..., description="Relevant excerpt from the rule")
+
+    @field_validator("page_number", mode="before")
+    @classmethod
+    def _coerce_na_to_none(cls, v: Any) -> Any:
+        if v == "N/A":
+            return None
+        return v
 
 
 class RelatedTerm(BaseModel):

--- a/src/services/agents/judge_agent.py
+++ b/src/services/agents/judge_agent.py
@@ -170,8 +170,10 @@ def extract_keywords(state: JudgeAgentState) -> dict:
             raise ValueError("Empty keyword response")
         logger.info(f"Extracted search keywords: {keywords}")
         return {"search_query": keywords}
-    except Exception as e:
-        logger.warning(f"Keyword extraction failed, falling back to original situation: {e}")
+    except (openai.APIError, ValueError, IndexError, AttributeError) as e:
+        logger.warning(
+            "Keyword extraction failed, falling back to original situation: %s", e
+        )
         return {"search_query": situation}
 
 
@@ -298,8 +300,9 @@ authoritative judgment based on official basketball rules.
 1. Analyze the described situation carefully.
 2. Determine whether it constitutes a violation, foul, legal play, or other.
 3. Provide clear reasoning citing specific rule articles from the retrieved data.
-4. Include every applicable rule_reference from the retrieved rules, each with the exact
-   article number, page number, and a verbatim excerpt from the rules.
+4. Include every applicable rule_reference from the retrieved rules. Copy the article
+   and page_number exactly as shown in the retrieved data; output null for any field
+   whose retrieved value is "N/A". Always include a verbatim excerpt.
 5. If relevant basketball terms appear in the glossary data, include them in
    related_terms with their definitions.
 6. Write the judgment_title as a concise Korean summary of the ruling.

--- a/src/services/agents/judge_agent.py
+++ b/src/services/agents/judge_agent.py
@@ -157,16 +157,22 @@ def extract_keywords(state: JudgeAgentState) -> dict:
         "키워드만 출력하고 다른 텍스트는 포함하지 마세요."
     )
 
-    response = chat_completion_with_retry(
-        model="gpt-4o",
-        messages=[
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": situation},
-        ],
-    )
-    keywords = (response.choices[0].message.content or "").strip()
-    logger.info(f"Extracted search keywords: {keywords}")
-    return {"search_query": keywords}
+    try:
+        response = chat_completion_with_retry(
+            model="gpt-4o",
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": situation},
+            ],
+        )
+        keywords = (response.choices[0].message.content or "").strip()
+        if not keywords:
+            raise ValueError("Empty keyword response")
+        logger.info(f"Extracted search keywords: {keywords}")
+        return {"search_query": keywords}
+    except Exception as e:
+        logger.warning(f"Keyword extraction failed, falling back to original situation: {e}")
+        return {"search_query": situation}
 
 
 def retrieve_rules_and_glossary(state: JudgeAgentState) -> dict:
@@ -176,7 +182,8 @@ def retrieve_rules_and_glossary(state: JudgeAgentState) -> dict:
     """
     logger.info("NODE: Retrieving Rules and Glossary")
     user_info = state["user_info"]
-    search_query = state.get("search_query") or user_info.get("situation_description", "")
+    original_situation = user_info.get("situation_description", "")
+    search_query = state.get("search_query") or original_situation
     rule_type = user_info.get("rule_type")
 
     logger.debug(
@@ -190,6 +197,18 @@ def retrieve_rules_and_glossary(state: JudgeAgentState) -> dict:
             n_rules=8,
             n_glossary=3,
         )
+
+        # Fallback: retry with original situation if keyword query yielded no rules
+        if not search_results["rules"] and search_query != original_situation:
+            logger.warning(
+                "Keyword query returned no rules; retrying with original situation"
+            )
+            search_results = rule_retriever.hybrid_search(
+                situation=original_situation,
+                rule_type=rule_type,
+                n_rules=8,
+                n_glossary=3,
+            )
 
         # Combine rules and glossary into context
         context_docs = search_results["rules"] + search_results["glossary"]
@@ -272,7 +291,7 @@ authoritative judgment based on official basketball rules.
 **CRITICAL CITATION RULES:**
 - You MUST cite rule articles ONLY from the "Retrieved Rules from Database" section above.
 - Do NOT cite, invent, or reference any rule articles not present in the retrieved data.
-- Every rule_reference MUST include: exact article number, page number, and a direct excerpt.
+- For each rule_reference, include the article number and page number ONLY if they are explicitly present in the retrieved data (not shown as "N/A"); never invent or infer missing values.
 - If retrieved rules are insufficient to make a judgment, state that explicitly instead of guessing.
 
 **Instructions:**

--- a/src/services/agents/judge_agent.py
+++ b/src/services/agents/judge_agent.py
@@ -53,6 +53,9 @@ class JudgeAgentState(TypedDict):
     # Information about the user's request (situation, rule_type).
     user_info: dict
 
+    # Violation-type keywords extracted from situation; used as the RAG query.
+    search_query: str
+
     # A list of relevant rule documents retrieved from the RAG store.
     context: List[Document]
 
@@ -138,6 +141,34 @@ def parse_situation(state: JudgeAgentState) -> dict:
     return {"user_info": sanitized_info}
 
 
+def extract_keywords(state: JudgeAgentState) -> dict:
+    """
+    Extracts violation-type keywords from the situation description using LLM.
+    These compact keywords are used as the RAG search query instead of the
+    full natural-language description, narrowing the embedding space mismatch
+    between long situation text and short official rule articles.
+    """
+    logger.info("NODE: Extracting Keywords")
+    situation = state["user_info"].get("situation_description", "")
+
+    system_prompt = (
+        "농구 경기 상황에서 규칙 위반 유형을 나타내는 핵심 키워드를 추출해줘. "
+        "출력 형식: 쉼표로 구분된 한국어 키워드 3-5개 (예: 파울, 트래블링, 바이얼레이션). "
+        "키워드만 출력하고 다른 텍스트는 포함하지 마세요."
+    )
+
+    response = chat_completion_with_retry(
+        model="gpt-4o",
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": situation},
+        ],
+    )
+    keywords = (response.choices[0].message.content or "").strip()
+    logger.info(f"Extracted search keywords: {keywords}")
+    return {"search_query": keywords}
+
+
 def retrieve_rules_and_glossary(state: JudgeAgentState) -> dict:
     """
     Retrieves relevant rules and glossary terms using the RuleRetriever.
@@ -145,18 +176,18 @@ def retrieve_rules_and_glossary(state: JudgeAgentState) -> dict:
     """
     logger.info("NODE: Retrieving Rules and Glossary")
     user_info = state["user_info"]
-    situation = user_info.get("situation_description", "")
+    search_query = state.get("search_query") or user_info.get("situation_description", "")
     rule_type = user_info.get("rule_type")
 
     logger.debug(
-        f"Search params: situation={(situation or '')[:80]}..., rule_type={rule_type}"
+        f"Search params: query={(search_query or '')[:80]}..., rule_type={rule_type}"
     )
 
     try:
         search_results = rule_retriever.hybrid_search(
-            situation=situation,
+            situation=search_query,
             rule_type=rule_type,
-            n_rules=5,
+            n_rules=8,
             n_glossary=3,
         )
 
@@ -238,12 +269,18 @@ authoritative judgment based on official basketball rules.
 {glossary_section}**Retrieved Rules from Database:**
 {rules_context_str}
 
+**CRITICAL CITATION RULES:**
+- You MUST cite rule articles ONLY from the "Retrieved Rules from Database" section above.
+- Do NOT cite, invent, or reference any rule articles not present in the retrieved data.
+- Every rule_reference MUST include: exact article number, page number, and a direct excerpt.
+- If retrieved rules are insufficient to make a judgment, state that explicitly instead of guessing.
+
 **Instructions:**
 1. Analyze the described situation carefully.
 2. Determine whether it constitutes a violation, foul, legal play, or other.
 3. Provide clear reasoning citing specific rule articles from the retrieved data.
-4. Include at least one rule_reference with the exact article, page number, and
-   an excerpt from the rules.
+4. Include every applicable rule_reference from the retrieved rules, each with the exact
+   article number, page number, and a verbatim excerpt from the rules.
 5. If relevant basketball terms appear in the glossary data, include them in
    related_terms with their definitions.
 6. Write the judgment_title as a concise Korean summary of the ruling.
@@ -296,12 +333,14 @@ workflow = StateGraph(JudgeAgentState)
 
 # Add nodes to the graph
 workflow.add_node("parse", parse_situation)
+workflow.add_node("extract_keywords", extract_keywords)
 workflow.add_node("retrieve", retrieve_rules_and_glossary)
 workflow.add_node("generate", generate_judgment)
 
 # Define the edges for the graph
 workflow.set_entry_point("parse")
-workflow.add_edge("parse", "retrieve")
+workflow.add_edge("parse", "extract_keywords")
+workflow.add_edge("extract_keywords", "retrieve")
 workflow.add_edge("retrieve", "generate")
 workflow.add_edge("generate", END)
 

--- a/src/services/rag/rule_retrieval.py
+++ b/src/services/rag/rule_retrieval.py
@@ -158,7 +158,7 @@ class RuleRetriever:
         self,
         situation: str,
         rule_type: Optional[str] = None,
-        n_rules: int = 5,
+        n_rules: int = 8,
         n_glossary: int = 3,
     ) -> Dict[str, List[Document]]:
         """


### PR DESCRIPTION
## 어떤 변경사항인가요?

The Whistle의 RAG 검색 품질 문제(LLM-as-Judge 평가: Accuracy 3.40, Citation 2.84)를 개선합니다. 긴 자연어 상황 설명을 그대로 embedding 쿼리로 사용하던 구조적 한계를 해결하기 위해, LLM으로 위반 유형 키워드를 추출해 RAG 쿼리로 쓰도록 노드를 분리했습니다. 또한 검색 결과 개수를 늘리고 조항 인용 규칙을 강제화해 Citation 품질을 높였습니다.

## 작업 상세 내용

- [x] `judge_agent.py`에 `extract_keywords` 노드 추가 — 상황 설명에서 위반 유형 키워드를 LLM으로 추출 후 검색 쿼리로 사용 (`parse → extract_keywords → retrieve → generate`)
- [x] `rule_retrieval.py` `n_rules` 기본값 5 → 8 증가 (호출부도 동일하게 수정)
- [x] `judge_agent.py` generate 프롬프트에 `CRITICAL CITATION RULES` 섹션 추가 — Retrieved Rules 외 조항 인용 금지, 조항 번호·페이지 필수 명시

## 체크리스트

- [x] self-test를 수행하였는가? (graph 컴파일·임포트 검증, ruff 린트 통과)
- [x] 관련 문서나 주석을 업데이트하였는가? (state 필드·노드 docstring 추가)
- [x] 설정한 코딩 컨벤션을 준수하였는가?

## 관련 이슈

- 관련 이슈: #106

## 리뷰 포인트

- **키워드 추출 프롬프트 품질**: "쉼표로 구분된 한국어 키워드 3-5개" 형식 지시가 LLM에 잘 전달되는지, 실제 embedding 검색 품질 향상으로 이어지는지 검토 부탁드립니다.
- **`extract_keywords` 에러 핸들링**: 현재 try/except 없이 `chat_completion_with_retry`의 retry 로직에만 의존합니다. 다른 노드(`retrieve_rules_and_glossary`)처럼 `ValueError`로 감쌀지 논의 필요.
- **CITATION RULES와 메타데이터 충돌**: 일부 rule 문서의 `article`/`page_number` 메타데이터가 `N/A`인 경우, "exact article number, page number" 요구와 상충할 수 있습니다.
- **`n_rules=8`의 적정성**: 상위 8개까지 가져올 때 관련 없는 룰이 포함돼 LLM 컨텍스트를 흐릴 가능성 vs 누락 방지 효과의 trade-off.

## 참고사항 및 스크린샷(선택)

- **원인 분석**: 상황 설명(긴 자연어) ↔ 조항 텍스트(짧은 공식 언어) 간 embedding 공간 불일치
- **검증 방법**:
  1. 서버 기동 후 `POST /api/v1/whistle/judge` 호출로 응답 구조 확인
  2. `uv run python src/evals/run_eval.py` 재실행 후 Accuracy·Citation 점수 비교
  3. 로그에서 `Extracted search keywords:` 출력으로 키워드 추출 품질 확인
- **LLM 비용 영향**: 요청당 LLM 호출 1회 추가 (`extract_keywords`, `gpt-4o`, ~50토큰 input / ~20토큰 output)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added intelligent keyword extraction from situation descriptions to improve rule search precision.

* **Improvements**
  * Expanded rule retrieval to return more rules and retry using the original text when keyword search yields no results.
  * Strengthened judgment citation requirements to mandate exact article/page references and verbatim excerpts; judgments will explicitly admit insufficiency rather than guess.
  * Removed the separate “consistency” metric from LLM judge outputs and reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->