### PR TITLE
[Feat] Whistle 평가 지표 Retrieval/Generation 레이어 분리 및 Faithfulness 추가

### DIFF
--- a/scripts/eval/metrics.py
+++ b/scripts/eval/metrics.py
@@ -87,20 +87,23 @@ def constraint_pass_rate(results: List[dict]) -> dict:
 def compute_llm_judge_metrics(results: List[Dict[str, Any]]) -> dict:
     """Aggregate LLM Judge scores.
 
-    Each result dict must have 'accuracy_score' and 'citation_score'.
+    Each result dict must have 'accuracy_score', 'citation_score',
+    and optionally 'faithfulness_score'.
     """
     if not results:
-        return {"accuracy": 0.0, "citation": 0.0}
+        return {"accuracy": 0.0, "citation": 0.0, "faithfulness": 0.0}
 
     valid_results = [r for r in results if r.get("accuracy_score") is not None]
     n = len(valid_results)
     if n == 0:
-        return {"accuracy": 0.0, "citation": 0.0}
+        return {"accuracy": 0.0, "citation": 0.0, "faithfulness": 0.0}
 
     total_accuracy = sum(r["accuracy_score"] for r in valid_results)
     total_citation = sum(r["citation_score"] for r in valid_results)
+    total_faithfulness = sum(r.get("faithfulness_score", 0) for r in valid_results)
 
     return {
         "accuracy": total_accuracy / n,
         "citation": total_citation / n,
+        "faithfulness": total_faithfulness / n,
     }

--- a/scripts/eval/metrics.py
+++ b/scripts/eval/metrics.py
@@ -100,7 +100,7 @@ def compute_llm_judge_metrics(results: List[Dict[str, Any]]) -> dict:
 
     total_accuracy = sum(r["accuracy_score"] for r in valid_results)
     total_citation = sum(r["citation_score"] for r in valid_results)
-    total_faithfulness = sum(r.get("faithfulness_score", 0) for r in valid_results)
+    total_faithfulness = sum(r.get("faithfulness_score") or 0 for r in valid_results)
 
     return {
         "accuracy": total_accuracy / n,

--- a/scripts/eval/report.py
+++ b/scripts/eval/report.py
@@ -67,33 +67,42 @@ def _gear_section(gear_data: dict) -> str:
 
 def _whistle_section(whistle_data: dict) -> str:
     """Build Whistle section of the report."""
+    retrieval = whistle_data.get("retrieval_metrics", {})
     rate = whistle_data["citation_hit_rate"]
     n = whistle_data["n_cases"]
     judge = whistle_data.get("llm_judge_metrics", {})
     details = whistle_data["details"]
 
     lines = [
-        "## Whistle: Citation Accuracy",
+        "## Whistle: RAG Evaluation",
+        "",
+        "### [1. Retrieval] DB가 문서를 잘 찾는가?",
         "",
         "| Metric | Value |",
         "|--------|-------|",
-        f"| Citation Hit Rate | {rate:.2f} |",
+        f"| Rule Hit@3 | {retrieval.get('hit_at_3', 0.0):.2f} |",
+        f"| Rule MRR | {retrieval.get('mrr', 0.0):.2f} |",
         f"| Cases | {n} |",
         "",
-        "### LLM Judge Metrics",
+        "### [2. Generation] LLM이 답변을 잘 만드는가?",
         "",
-        f"- Accuracy: {judge.get('accuracy', 0.0):.2f} / 5.0",
-        f"- Citation: {judge.get('citation', 0.0):.2f} / 5.0",
+        "| Metric | Value |",
+        "|--------|-------|",
+        f"| Citation Hit Rate (Rule-based) | {rate:.2f} |",
+        f"| Accuracy (LLM Judge) | {judge.get('accuracy', 0.0):.2f} / 5.0 |",
+        f"| Citation (LLM Judge) | {judge.get('citation', 0.0):.2f} / 5.0 |",
+        f"| Faithfulness (LLM Judge) | {judge.get('faithfulness', 0.0):.2f} / 5.0 |",
         "",
         "### Case Details",
         "",
-        "| ID | Description | Expected Decision | Predicted Decision | Decision Match | Expected Articles | Predicted Articles | Citation Hit | LLM Judge |",  # noqa: E501
-        "|----|-------------|-------------------|-------------------|----------------|-------------------|-------------------|--------------|-----------|",
+        "| ID | Description | Expected | Predicted | Match | Retrieved | Cited | Cit Hit | LLM Judge |",  # noqa: E501
+        "|----|-------------|----------|-----------|-------|-----------|-------|---------|-----------|",
     ]
 
     for d in details:
         decision_match = "O" if d["decision_match"] else "X"
         exp_art = ", ".join(d["expected_articles"])
+        retr_art = ", ".join(d.get("retrieved_articles", [])[:3]) or "-"
         pred_art = ", ".join(d["predicted_articles"]) or "-"
         citation_hit = (
             "O"
@@ -102,11 +111,11 @@ def _whistle_section(whistle_data: dict) -> str:
         )
 
         js = d.get("llm_judge_score", {})
-        judge_str = f"A:{js.get('accuracy_score', 0)} Cit:{js.get('citation_score', 0)}"  # noqa: E501
+        judge_str = f"A:{js.get('accuracy_score', 0)} C:{js.get('citation_score', 0)} F:{js.get('faithfulness_score', 0)}"  # noqa: E501
 
         lines.append(
             f"| {d['id']} | {d['description']} | {d['expected_decision']} "
-            f"| {d['predicted_decision']} | {decision_match} | {exp_art} | {pred_art} | {citation_hit} | {judge_str} |"  # noqa: E501
+            f"| {d['predicted_decision']} | {decision_match} | {retr_art} | {pred_art} | {citation_hit} | {judge_str} |"  # noqa: E501
         )
 
     lines.append("")

--- a/scripts/eval/runners/judge_llm_runner.py
+++ b/scripts/eval/runners/judge_llm_runner.py
@@ -23,6 +23,7 @@ def evaluate_with_llm_judge(
     Criteria:
     1. 정확성 (Accuracy)
     2. 규칙 인용 적절성 / 데이터 충실도 (도메인별 의미 차이)
+    3. 원문 충실도 (Faithfulness) — Whistle 전용, Gear는 0 반환
     """
 
     prompt = prompt_template.format(
@@ -61,6 +62,7 @@ def evaluate_with_llm_judge(
         return {
             "accuracy_score": int(parsed.get("accuracy_score", 0)),
             "citation_score": int(parsed.get("citation_score", 0)),
+            "faithfulness_score": int(parsed.get("faithfulness_score", 0)),
             "reasoning": str(parsed.get("reasoning", "")),
         }
 
@@ -69,6 +71,7 @@ def evaluate_with_llm_judge(
         return {
             "accuracy_score": 0,
             "citation_score": 0,
+            "faithfulness_score": 0,
             "reasoning": f"JSON Parsing Error: {str(e)}",
         }
     except Exception as e:
@@ -76,5 +79,6 @@ def evaluate_with_llm_judge(
         return {
             "accuracy_score": 0,
             "citation_score": 0,
+            "faithfulness_score": 0,
             "reasoning": f"API Error: {str(e)}",
         }

--- a/scripts/eval/runners/whistle_runner.py
+++ b/scripts/eval/runners/whistle_runner.py
@@ -12,7 +12,12 @@ from pathlib import Path
 
 from langchain_core.messages import HumanMessage
 
-from scripts.eval.metrics import citation_hit_rate, compute_llm_judge_metrics
+from scripts.eval.metrics import (
+    citation_hit_rate,
+    compute_llm_judge_metrics,
+    hit_at_k,
+    reciprocal_rank,
+)
 from scripts.eval.runners.judge_llm_runner import evaluate_with_llm_judge
 from src.core.constants import LLM_JUDGE_WHISTLE_PROMPT, LLM_JUDGE_WHISTLE_SYSTEM_PROMPT
 from src.models.rule_schema import WhistleResponse
@@ -55,6 +60,13 @@ def _run_single_whistle(case: dict) -> dict:
         "\n".join([doc.page_content for doc in context_docs]) if context_docs else ""
     )
 
+    # Retrieval-level: articles present in retrieved rule docs
+    retrieved_articles = [
+        _normalize_article(doc.metadata["article"])
+        for doc in context_docs
+        if doc.metadata.get("doc_type") == "rule" and doc.metadata.get("article")
+    ]
+
     response = WhistleResponse.model_validate_json(raw)
 
     predicted_articles = [
@@ -62,6 +74,7 @@ def _run_single_whistle(case: dict) -> dict:
     ]
     return {
         "predicted_articles": predicted_articles,
+        "retrieved_articles": retrieved_articles,
         "predicted_decision": response.decision,
         "raw_response": raw,
         "context": context_text,
@@ -78,6 +91,7 @@ def run_whistle_evaluation() -> dict:
         cases = json.load(f)
 
     citation_results = []
+    retrieval_results = []
     llm_judge_results = []
     details = []
 
@@ -91,12 +105,14 @@ def run_whistle_evaluation() -> dict:
         try:
             result = _run_single_whistle(case)
             predicted_articles = result["predicted_articles"]
+            retrieved_articles = result["retrieved_articles"]
             predicted_decision = result["predicted_decision"]
             raw_response = result["raw_response"]
             context_text = result["context"]
         except Exception as e:
             logger.error("Whistle failed for %s: %s", case_id, e)
             predicted_articles = []
+            retrieved_articles = []
             predicted_decision = "error"
             raw_response = ""
             context_text = ""
@@ -107,6 +123,7 @@ def run_whistle_evaluation() -> dict:
             llm_judge_score = {
                 "accuracy_score": 0,
                 "citation_score": 0,
+                "faithfulness_score": 0,
                 "reasoning": "Skipped: agent failed",
             }
         else:
@@ -127,12 +144,20 @@ def run_whistle_evaluation() -> dict:
                 llm_judge_score = {
                     "accuracy_score": 0,
                     "citation_score": 0,
+                    "faithfulness_score": 0,
                     "reasoning": "Error",
                 }
 
         citation_results.append(
             {
                 "predicted_articles": predicted_articles,
+                "expected_articles": expected_articles,
+            }
+        )
+
+        retrieval_results.append(
+            {
+                "retrieved_articles": retrieved_articles,
                 "expected_articles": expected_articles,
             }
         )
@@ -148,22 +173,34 @@ def run_whistle_evaluation() -> dict:
                 "predicted_decision": predicted_decision,
                 "decision_match": decision_match,
                 "expected_articles": expected_articles,
+                "retrieved_articles": retrieved_articles,
                 "predicted_articles": predicted_articles,
                 "llm_judge_score": llm_judge_score,
             }
         )
 
         logger.info(
-            "  %s → decision: %s (expected: %s) | articles: %s (expected: %s) | Judge: %s",  # noqa: E501
+            "  %s → decision: %s (expected: %s) | retrieved: %s | cited: %s | Judge: %s",  # noqa: E501
             case_id,
             predicted_decision,
             expected_decision,
+            retrieved_articles,
             predicted_articles,
-            expected_articles,
-            f"A:{llm_judge_score.get('accuracy_score')} Cit:{llm_judge_score.get('citation_score')}"  # noqa: E501,
+            f"A:{llm_judge_score.get('accuracy_score')} Cit:{llm_judge_score.get('citation_score')} Faith:{llm_judge_score.get('faithfulness_score')}"  # noqa: E501,
         )
 
+    n = len(retrieval_results)
+    hit3 = sum(
+        hit_at_k(r["retrieved_articles"], r["expected_articles"], k=3)
+        for r in retrieval_results
+    ) / n if n else 0.0
+    mrr = sum(
+        reciprocal_rank(r["retrieved_articles"], r["expected_articles"])
+        for r in retrieval_results
+    ) / n if n else 0.0
+
     return {
+        "retrieval_metrics": {"hit_at_3": hit3, "mrr": mrr, "n_cases": n},
         "citation_hit_rate": citation_hit_rate(citation_results),
         "llm_judge_metrics": compute_llm_judge_metrics(llm_judge_results),
         "n_cases": len(cases),

--- a/scripts/eval/runners/whistle_runner.py
+++ b/scripts/eval/runners/whistle_runner.py
@@ -60,12 +60,15 @@ def _run_single_whistle(case: dict) -> dict:
         "\n".join([doc.page_content for doc in context_docs]) if context_docs else ""
     )
 
-    # Retrieval-level: articles present in retrieved rule docs
-    retrieved_articles = [
-        _normalize_article(doc.metadata["article"])
-        for doc in context_docs
-        if doc.metadata.get("doc_type") == "rule" and doc.metadata.get("article")
-    ]
+    # Retrieval-level: unique articles in retrieved rule docs (insertion-order dedup)
+    seen: set[str] = set()
+    retrieved_articles = []
+    for doc in context_docs:
+        if doc.metadata.get("doc_type") == "rule" and doc.metadata.get("article"):
+            art = _normalize_article(doc.metadata["article"])
+            if art not in seen:
+                seen.add(art)
+                retrieved_articles.append(art)
 
     response = WhistleResponse.model_validate_json(raw)
 

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -157,17 +157,20 @@ LLM_JUDGE_WHISTLE_SYSTEM_PROMPT = (
 
 LLM_JUDGE_WHISTLE_PROMPT = (
     "다음 농구 규칙 판정 답변을 평가하고, "
-    "지정된 2가지 기준에 따라 1점부터 5점까지 채점해.\n"
+    "지정된 3가지 기준에 따라 1점부터 5점까지 채점해.\n"
     "반드시 마크다운 코드 블록 없이 순수한 JSON 형태({{...}})로만 출력해라.\n\n"
     "평가 기준:\n"
     "1. 정확성 (Accuracy): 생성된 답변이 예상 정답(판정)과 일치하며, "
     "농구 규정에 맞게 상황을 정확히 판단했는가?\n"
     "2. 규칙 인용 적절성 (Citation Appropriateness): 근거로 제시한 조항(Article)이 "
-    "주어진 상황에 적절하며 올바르게 인용되었는가?\n\n"
+    "주어진 상황에 적절하며 올바르게 인용되었는가?\n"
+    "3. 원문 충실도 (Faithfulness): 답변이 검색된 규칙 원문(Context)에 근거하며, "
+    "실제로 존재하지 않는 조항을 지어내거나 임의로 내용을 추가하지 않았는가?\n\n"
     "출력 형식 (오직 순수 JSON만 반환):\n"
     "{{\n"
     '  "accuracy_score": <int>,\n'
     '  "citation_score": <int>,\n'
+    '  "faithfulness_score": <int>,\n'
     '  "reasoning": "<string explaining the scores in Korean>"\n'
     "}}\n\n"
     "---\n"


### PR DESCRIPTION
## 어떤 변경사항인가요?

Whistle RAG 평가 지표를 **Retrieval / Generation 두 레이어로 분리**하고, LLM-as-Judge에 원문 충실도(Faithfulness) 기준을 추가합니다.

## 작업 상세 내용

- [x] `whistle_runner.py` — retrieved docs에서 article 번호 추출, Rule Hit@3 / MRR 계산 추가
- [x] `constants.py` — `LLM_JUDGE_WHISTLE_PROMPT` 평가 기준 2개 → 3개로 확장 (Accuracy, Citation, Faithfulness)
- [x] `judge_llm_runner.py` — 반환값에 `faithfulness_score` 필드 추가
- [x] `metrics.py` — `compute_llm_judge_metrics`에 faithfulness 집계 추가
- [x] `report.py` — Whistle 섹션을 [Retrieval] / [Generation] 구역으로 분리 출력

## 체크리스트

- [ ] self-test를 수행하였는가?
- [x] 관련 문서나 주석을 업데이트하였는가?
- [x] 설정한 코딩 컨벤션을 준수하였는가?

## 관련 이슈

- 관련 이슈: #106 후속

## 리뷰 포인트

- Retrieval 메트릭(Hit@3, MRR)은 ChromaDB가 **실제로 검색한 문서** 기준으로 측정합니다. 기존 Citation Hit Rate(LLM이 인용한 조항 기준)와 측정 대상이 다릅니다.
- Faithfulness는 "LLM이 존재하지 않는 규칙을 지어냈는가?"를 묻는 기준으로, 기존 Citation Appropriateness("상황에 맞는 조항인가?")와 별개로 측정합니다.
- self-test는 API 크레딧 확보 후 수행 예정입니다.

## 참고사항 및 스크린샷(선택)

**평가 지표 구조 변경 전/후**

| | Before | After |
|--|--------|-------|
| Retrieval | - | Rule Hit@3, Rule MRR |
| Generation (Rule-based) | Citation Hit Rate | Citation Hit Rate |
| Generation (LLM Judge) | Accuracy, Citation | Accuracy, Citation, **Faithfulness** |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Faithfulness metric to evaluate grounding of LLM responses.
  * Added Retrieval metrics (Hit@3, MRR) to evaluation outputs.
  * Reports now show separate Retrieval and Generation sections and include a truncated view of retrieved items per case.

* **Improvements**
  * LLM judge output and report rendering expanded to include faithfulness alongside accuracy and citation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->