### PR TITLE
[Feat] Skill Lab eval에 RAG baseline 추가 및 테스트 버그 수정  

### DIFF
--- a/scripts/eval/baseline_skill.py
+++ b/scripts/eval/baseline_skill.py
@@ -108,7 +108,6 @@ def run_rag_baseline_skill(user_input: dict) -> SkillLabResponse:
         )
     )
 
-    from src.models.skill_schema import Step  # noqa: F401 — used via SkillLabResponse
     schema_json = json.dumps(SkillLabResponse.model_json_schema(), indent=2)
     language_name = "Korean" if language == "ko" else "English"
 

--- a/scripts/eval/baseline_skill.py
+++ b/scripts/eval/baseline_skill.py
@@ -1,0 +1,182 @@
+"""RAG-based baseline for Skill Lab evaluation.
+
+Simulates the old coach agent pipeline (diagnose → retrieve → generate)
+by loading drills from drills.json, filtering by category and equipment,
+and injecting them into the same prompt used by the current LLM-only agent.
+
+This baseline mirrors the retrieval logic from the removed retrieve_drills node
+(commit d8436c8) to enable a fair RAG vs LLM-only comparison.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from src.core.constants import KO_BASKETBALL_TERMINOLOGY
+from src.models.skill_schema import SkillLabResponse
+from src.utils.llm import chat_completion_with_retry
+
+logger = logging.getLogger(__name__)
+
+DATA_DIR = Path(__file__).resolve().parent.parent.parent / "data" / "raw"
+MAX_DRILLS = 10
+
+
+def _load_drills() -> list:
+    with open(DATA_DIR / "drills.json", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _filter_drills(drills: list, category: str, user_equipment: set) -> list:
+    """Filter drills by category then by equipment availability.
+
+    Mirrors the original retrieve_drills node logic:
+    1. Category filter (same as ChromaDB where_filter)
+    2. Equipment filter (required_equipment must be subset of user_equipment)
+    3. Cap at MAX_DRILLS results
+    """
+    category_filtered = [d for d in drills if d.get("category") == category] if category else drills
+
+    equipment_filtered = []
+    for drill in category_filtered:
+        required = set(drill.get("required_equipment", []))
+        if not required or required.issubset(user_equipment):
+            equipment_filtered.append(drill)
+
+    return equipment_filtered[:MAX_DRILLS]
+
+
+def _build_context_str(drills: list, language: str) -> str:
+    """Build context string in the same format as the old retrieve_drills node."""
+    if not drills:
+        return "No specific drills found in the database."
+
+    lines = []
+    for drill in drills:
+        name = drill.get("name_ko") or drill.get("name", "N/A") if language == "ko" else drill.get("name", "N/A")
+        required_equip = drill.get("required_equipment", [])
+        equip_str = ", ".join(required_equip) if required_equip else "none"
+        lines.append(
+            f"Drill Name: {name}\n"
+            f"Difficulty: {drill.get('difficulty', 'N/A')}\n"
+            f"Suggested Duration: {drill.get('duration_min', 'N/A')} min\n"
+            f"Required Equipment: {equip_str}\n"
+            f"Description: {drill.get('description', 'N/A')}"
+        )
+    return "\n\n".join(lines)
+
+
+def run_rag_baseline_skill(user_input: dict) -> SkillLabResponse:
+    """Run skill breakdown with RAG-based drill injection (old pipeline).
+
+    Args:
+        user_input: Dict with skill_level, category, available_time_min,
+                    equipment, language, and optional specific_skill.
+
+    Returns:
+        Validated SkillLabResponse.
+
+    Raises:
+        ValueError: If LLM response cannot be parsed/validated.
+    """
+    category = user_input.get("category", "")
+    skill_level = user_input.get("skill_level", "intermediate")
+    available_time = user_input.get("available_time_min", 20)
+    specific_skill = user_input.get("specific_skill") or ""
+    language = user_input.get("language", "en")
+    user_equipment = set(user_input.get("equipment", []))
+
+    all_drills = _load_drills()
+    filtered_drills = _filter_drills(all_drills, category, user_equipment)
+    context_str = _build_context_str(filtered_drills, language)
+
+    logger.info(
+        "RAG baseline: %d drills after filtering (category=%s, equipment=%s)",
+        len(filtered_drills),
+        category,
+        user_equipment,
+    )
+
+    skill_instruction = (
+        f'The user wants to master: "{specific_skill}".'
+        if specific_skill
+        else (
+            f"The user did not specify a skill. Pick the most impactful "
+            f"{category} technique for a {skill_level} player and set it as skill_name."
+        )
+    )
+
+    from src.models.skill_schema import Step  # noqa: F401 — used via SkillLabResponse
+    schema_json = json.dumps(SkillLabResponse.model_json_schema(), indent=2)
+    language_name = "Korean" if language == "ko" else "English"
+
+    prompt = f"""You are an expert basketball skills coach who specializes in
+breaking down individual techniques into progressive micro-steps.
+
+**User Profile:**
+- Skill Level: {skill_level}
+- Category: {category}
+- Available Time: {available_time} minutes
+- Available Equipment: {list(user_equipment)}
+- Additional Focus: None
+- Intensity Preference: None
+- Special Notes: None
+- Additional Request (raw): None
+
+**Skill Selection:**
+{skill_instruction}
+
+**Reference Drills from Database (use as inspiration):**
+{context_str}
+
+**Language:**
+Respond in {language_name}. All string fields (skill_name, coach_message,
+step name, description, focus_point, success_criteria) must be in {language_name}.
+
+**Instructions:**
+1. Break the skill into 3-5 progressive steps, ordered from simplest to
+   most game-like:
+   - Step 1: MUST start with no ball or stationary movement (anyone can do it)
+   - Each subsequent step adds exactly ONE layer of complexity
+     (e.g., add ball → add movement → add speed → add defender/obstacle)
+   - The final step MUST simulate a real game situation
+2. The sum of all step durations MUST equal exactly {available_time} minutes.
+3. Each step must have:
+   - A clear, descriptive name
+   - A description: step-by-step execution with specific reps, sets, or targets (3-4 sentences minimum)
+   - A focus_point: the ONE thing to concentrate on in this step
+   - A success_criteria: a measurable goal to pass this step
+4. Each step must include a concrete target or success metric.
+5. Set difficulty_level to a short phrase showing the progression range.
+6. Write a motivating coach_message about mastering this specific skill.
+7. Output a JSON object strictly following this schema:
+
+```json
+{schema_json}
+```
+
+JSON Output:
+"""
+
+    messages = []
+    if language == "ko":
+        messages.append({"role": "system", "content": KO_BASKETBALL_TERMINOLOGY})
+    messages.append({"role": "user", "content": prompt})
+
+    response = chat_completion_with_retry(
+        model="gpt-4o",
+        messages=messages,
+        response_format={"type": "json_object"},
+    )
+
+    if not response.choices or not response.choices[0].message.content:
+        raise ValueError("Empty response from LLM for RAG baseline skill.")
+
+    content = response.choices[0].message.content
+    try:
+        return SkillLabResponse.model_validate_json(content)
+    except (json.JSONDecodeError, ValidationError) as e:
+        logger.error("Failed to parse RAG baseline response: %s (raw: %.500s)", e, content)
+        raise ValueError("RAG baseline LLM returned invalid response") from e

--- a/scripts/eval/report.py
+++ b/scripts/eval/report.py
@@ -124,36 +124,35 @@ def _whistle_section(whistle_data: dict) -> str:
 
 def _skill_section(skill_data: dict) -> str:
     """Build Skill Lab section of the report."""
-    rates = skill_data["constraint_pass_rate"]
+    llm_rates = skill_data["llm_constraint_pass_rate"]
+    rag_rates = skill_data["rag_constraint_pass_rate"]
     n = skill_data["n_cases"]
     details = skill_data["details"]
 
     lines = [
-        "## Skill Lab: Constraint Compliance",
+        "## Skill Lab: LLM-only vs RAG Baseline",
         "",
-        "| Metric | Value |",
-        "|--------|-------|",
-        f"| Equipment Pass Rate | {rates['equipment']:.2f} |",
-        f"| Time Pass Rate | {rates['time']:.2f} |",
-        f"| Cases | {n} |",
+        "| Metric | LLM-only | RAG Baseline | Delta |",
+        "|--------|----------|--------------|-------|",
+        f"| Equipment Pass Rate | {llm_rates['equipment']:.2f} | {rag_rates['equipment']:.2f} "
+        f"| {llm_rates['equipment'] - rag_rates['equipment']:+.2f} |",
+        f"| Time Pass Rate | {llm_rates['time']:.2f} | {rag_rates['time']:.2f} "
+        f"| {llm_rates['time'] - rag_rates['time']:+.2f} |",
+        f"| Cases | {n} | {n} | - |",
         "",
         "### Case Details",
         "",
-        "| ID | Description | Equipment | Time | Steps |",
-        "|----|-------------|-----------|------|-------|",
+        "| ID | Description | LLM Equip | LLM Time | RAG Equip | RAG Time |",
+        "|----|-------------|-----------|----------|-----------|----------|",
     ]
 
     for d in details:
-        equip = "PASS" if d["equipment_pass"] else "FAIL"
-        time = "PASS" if d["time_pass"] else "FAIL"
-        if d["steps"]:
-            step_summary = ", ".join(
-                f"{s['name']}({s['duration_min']}m)" for s in d["steps"]
-            )
-        else:
-            step_summary = "-"
         lines.append(
-            f"| {d['id']} | {d['description']} | {equip} | {time} | {step_summary} |"
+            f"| {d['id']} | {d['description']} "
+            f"| {'PASS' if d['llm_equipment_pass'] else 'FAIL'} "
+            f"| {'PASS' if d['llm_time_pass'] else 'FAIL'} "
+            f"| {'PASS' if d['rag_equipment_pass'] else 'FAIL'} "
+            f"| {'PASS' if d['rag_time_pass'] else 'FAIL'} |"
         )
 
     lines.append("")

--- a/scripts/eval/runners/skill_runner.py
+++ b/scripts/eval/runners/skill_runner.py
@@ -1,7 +1,7 @@
 """Skill Lab evaluation runner.
 
-Runs each skill case through the coach agent graph,
-then verifies equipment and time constraints.
+Runs each skill case through both the current LLM-only agent and the
+RAG-based baseline (old pipeline), then compares constraint compliance.
 """
 
 import json
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from langchain_core.messages import HumanMessage
 
+from scripts.eval.baseline_skill import run_rag_baseline_skill
 from scripts.eval.metrics import constraint_pass_rate
 from src.models.skill_schema import SkillLabResponse
 from src.services.agents.coach_agent import coach_agent_graph
@@ -18,7 +19,6 @@ logger = logging.getLogger(__name__)
 
 DATASETS_DIR = Path(__file__).resolve().parent.parent / "datasets"
 
-# Equipment keywords that indicate usage of specific equipment
 EQUIPMENT_KEYWORDS = {
     "hoop": ["hoop", "rim", "basket", "backboard"],
     "cones": ["cone", "cones", "marker", "markers"],
@@ -26,25 +26,13 @@ EQUIPMENT_KEYWORDS = {
     "ball": ["ball", "dribble", "shoot", "pass"],
 }
 
-# Phrases that mention equipment conceptually but don't require it
-SIMULATION_EXCEPTIONS = [
-    "imagin", "visualiz", "pretend", "shadow", "simulate",
-    "as if", "invisible",
-]
-
 
 def _check_equipment_constraint(
     response: SkillLabResponse,
     max_equipment: list[str],
 ) -> bool:
-    """Check if response only uses allowed equipment.
-
-    Scans step names and descriptions for equipment keywords
-    that are NOT in the user's available equipment list.
-    """
     allowed = set(max_equipment)
 
-    # Collect all text from steps for scanning
     texts = []
     for step in response.steps:
         texts.append(step.name.lower())
@@ -54,7 +42,6 @@ def _check_equipment_constraint(
 
     for equip, keywords in EQUIPMENT_KEYWORDS.items():
         if equip in allowed or equip == "ball":
-            # ball is almost always implicitly allowed in basketball drills
             continue
         for keyword in keywords:
             if keyword in combined_text:
@@ -73,7 +60,6 @@ def _check_time_constraint(
     response: SkillLabResponse,
     target_time_min: int,
 ) -> bool:
-    """Check if total duration matches the target time."""
     actual = sum(step.duration_min for step in response.steps)
     matches = actual == target_time_min
     if not matches:
@@ -85,8 +71,8 @@ def _check_time_constraint(
     return matches
 
 
-def _run_single_skill(case: dict) -> SkillLabResponse:
-    """Run a single skill case through the coach agent."""
+def _run_llm_only(case: dict) -> SkillLabResponse:
+    """Run a single case through the current LLM-only coach agent."""
     user_input = case["input"]
     skill_desc = (
         f"{user_input.get('skill_level', '')} "
@@ -112,16 +98,40 @@ def _run_single_skill(case: dict) -> SkillLabResponse:
     return SkillLabResponse.model_validate_json(raw)
 
 
+def _run_rag_baseline(case: dict) -> SkillLabResponse:
+    """Run a single case through the RAG-based baseline (old pipeline)."""
+    user_input = case["input"]
+    return run_rag_baseline_skill({
+        "skill_level": user_input["skill_level"],
+        "category": user_input["category"],
+        "available_time_min": user_input["available_time_min"],
+        "equipment": user_input.get("equipment", []),
+        "language": user_input.get("language", "en"),
+        "specific_skill": user_input.get("specific_skill"),
+    })
+
+
+def _evaluate_response(
+    response: SkillLabResponse,
+    constraints: dict,
+) -> tuple[bool, bool, list]:
+    equip_pass = _check_equipment_constraint(response, constraints["max_equipment"])
+    time_pass = _check_time_constraint(response, constraints["target_time_min"])
+    steps = [{"name": s.name, "duration_min": s.duration_min} for s in response.steps]
+    return equip_pass, time_pass, steps
+
+
 def run_skill_evaluation() -> dict:
-    """Run full skill lab evaluation for all cases.
+    """Run full skill lab evaluation comparing LLM-only vs RAG baseline.
 
     Returns:
-        Dict with 'constraint_pass_rate', 'n_cases', and 'details' per case.
+        Dict with constraint pass rates for both pipelines, n_cases, and per-case details.
     """
     with open(DATASETS_DIR / "skill_cases.json", encoding="utf-8") as f:
         cases = json.load(f)
 
-    constraint_results = []
+    llm_results = []
+    rag_results = []
     details = []
 
     for case in cases:
@@ -129,45 +139,48 @@ def run_skill_evaluation() -> dict:
         constraints = case["constraints"]
         logger.info("Running skill case: %s", case_id)
 
+        # LLM-only (current)
         try:
-            response = _run_single_skill(case)
-            equip_pass = _check_equipment_constraint(
-                response, constraints["max_equipment"]
-            )
-            time_pass = _check_time_constraint(
-                response, constraints["target_time_min"]
-            )
-            step_summary = [
-                {"name": s.name, "duration_min": s.duration_min}
-                for s in response.steps
-            ]
+            llm_response = _run_llm_only(case)
+            llm_equip, llm_time, llm_steps = _evaluate_response(llm_response, constraints)
         except Exception as e:
-            logger.error("Skill failed for %s: %s", case_id, e)
-            equip_pass = False
-            time_pass = False
-            step_summary = []
+            logger.error("LLM-only failed for %s: %s", case_id, e)
+            llm_equip, llm_time, llm_steps = False, False, []
 
-        constraint_results.append({
-            "equipment_pass": equip_pass,
-            "time_pass": time_pass,
-        })
+        # RAG baseline (old pipeline)
+        try:
+            rag_response = _run_rag_baseline(case)
+            rag_equip, rag_time, rag_steps = _evaluate_response(rag_response, constraints)
+        except Exception as e:
+            logger.error("RAG baseline failed for %s: %s", case_id, e)
+            rag_equip, rag_time, rag_steps = False, False, []
+
+        llm_results.append({"equipment_pass": llm_equip, "time_pass": llm_time})
+        rag_results.append({"equipment_pass": rag_equip, "time_pass": rag_time})
+
         details.append({
             "id": case_id,
             "description": case["description"],
-            "equipment_pass": equip_pass,
-            "time_pass": time_pass,
-            "steps": step_summary,
+            "llm_equipment_pass": llm_equip,
+            "llm_time_pass": llm_time,
+            "llm_steps": llm_steps,
+            "rag_equipment_pass": rag_equip,
+            "rag_time_pass": rag_time,
+            "rag_steps": rag_steps,
         })
 
         logger.info(
-            "  %s → equipment: %s | time: %s",
+            "  %s → LLM(equip:%s time:%s) | RAG(equip:%s time:%s)",
             case_id,
-            "PASS" if equip_pass else "FAIL",
-            "PASS" if time_pass else "FAIL",
+            "PASS" if llm_equip else "FAIL",
+            "PASS" if llm_time else "FAIL",
+            "PASS" if rag_equip else "FAIL",
+            "PASS" if rag_time else "FAIL",
         )
 
     return {
-        "constraint_pass_rate": constraint_pass_rate(constraint_results),
+        "llm_constraint_pass_rate": constraint_pass_rate(llm_results),
+        "rag_constraint_pass_rate": constraint_pass_rate(rag_results),
         "n_cases": len(cases),
         "details": details,
     }

--- a/scripts/eval/runners/skill_runner.py
+++ b/scripts/eval/runners/skill_runner.py
@@ -90,6 +90,7 @@ def _run_llm_only(case: dict) -> SkillLabResponse:
             "available_time_min": user_input["available_time_min"],
             "equipment": user_input.get("equipment", []),
             "language": user_input.get("language", "en"),
+            "specific_skill": user_input.get("specific_skill"),
         },
     }
 

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -74,8 +74,12 @@ def main():
 
         skill_data = run_skill_evaluation()
         logger.info(
-            "Skill Constraint Pass Rate: %s",
-            skill_data["constraint_pass_rate"],
+            "Skill LLM-only Constraint Pass Rate: %s",
+            skill_data["llm_constraint_pass_rate"],
+        )
+        logger.info(
+            "Skill RAG Baseline Constraint Pass Rate: %s",
+            skill_data["rag_constraint_pass_rate"],
         )
 
     report_path = generate_report(gear_data, whistle_data, skill_data)

--- a/tests/test_skill_lab.py
+++ b/tests/test_skill_lab.py
@@ -11,7 +11,7 @@ Test Cases:
 """
 
 import json
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -82,9 +82,10 @@ def test_client():
 
 @pytest.fixture
 def mock_coach():
-    """Patch coach_agent_graph.invoke to return a canned response."""
+    """Patch coach_agent_graph.ainvoke to return a canned response."""
     with patch(
-        "src.api.v1.endpoints.skill.coach_agent_graph.invoke",
+        "src.api.v1.endpoints.skill.coach_agent_graph.ainvoke",
+        new_callable=AsyncMock,
         return_value={"final_response": json.dumps(_FAKE_SKILL_RESPONSE)},
     ) as mock:
         yield mock
@@ -142,7 +143,7 @@ class TestSkillLabAPI:
         available_time_min과 steps duration 합계가 일치
         """
         # Arrange
-        available_time = 30
+        available_time = 20  # matches _FAKE_SKILL_RESPONSE total_duration_min
         payload = {
             "skill_level": "beginner",
             "category": "shooting",
@@ -163,6 +164,10 @@ class TestSkillLabAPI:
         assert total_step_duration == data["total_duration_min"], (
             f"Sum of step durations ({total_step_duration}) should equal "
             f"total_duration_min ({data['total_duration_min']})"
+        )
+        assert data["total_duration_min"] == available_time, (
+            f"total_duration_min ({data['total_duration_min']}) should equal "
+            f"requested available_time_min ({available_time})"
         )
 
     def test_tc04_free_text_parsing(self, test_client, mock_coach):


### PR DESCRIPTION
## 어떤 변경사항인가요?

Skill Lab eval에 RAG 기반 baseline을 추가해 현재 LLM-only 파이프라인과 제약조건 준수율을 비교할 수 있도록 합니다.
기존에는 LLM-only 결과만 측정했지만, RAG 제거 결정을 데이터로 뒷받침할 근거가 없었습니다.
또한 기존 테스트 코드의 mock 오류 및 시간 검증 누락 버그를 함께 수정합니다.

## 작업 상세 내용

- [x] `baseline_skill.py` 신규 작성 — 삭제된 `retrieve_drills` 노드(commit d8436c8) 로직 복원: `drills.json`에서 카테고리·장비 필터링 후 프롬프트에 컨텍스트 주입
- [x] `skill_runner.py` 수정 — 케이스당 LLM-only / RAG baseline 두 파이프라인 병렬 실행 및 constraint 비교, `specific_skill` 누락 필드 추가
- [x] `report.py` 수정 — Skill Lab 섹션을 Gear Advisor 형식과 동일하게 LLM-only vs RAG Baseline 비교 테이블로 변경
- [x] `evaluate.py` 수정 — 변경된 반환 키(`llm_constraint_pass_rate`, `rag_constraint_pass_rate`) 반영
- [x] `test_skill_lab.py` 버그 수정
  - `mock_coach`가 `invoke`를 패치했으나 엔드포인트는 `ainvoke` 사용 → `AsyncMock`으로 교체
  - TC-03 시간 검증이 응답 내부 일관성만 확인, 요청 시간과 비교 누락 → 단언 추가 및 `available_time` 수정

## 체크리스트

- [x] self-test를 수행하였는가?
- [x] 관련 문서나 주석을 업데이트하였는가?
- [x] 설정한 코딩 컨벤션을 준수하였는가?

## 관련 이슈

- 관련 이슈: 없음

## 리뷰 포인트

- `baseline_skill.py`의 `_filter_drills`는 ChromaDB semantic ranking 없이 카테고리 + 장비 필터만 사용합니다. 실제 옛 RAG는 벡터 유사도로 상위 10개를 뽑았으므로 완전히 동일한 재현은 아닙니다. 비교의 방향성(필터 기반 RAG vs LLM-only)이 적절한지 확인 부탁드립니다.
- API 크레딧 부족으로 실제 eval 수치는 아직 없습니다. 크레딧 충전 후 `uv run python scripts/evaluate.py --skill`로 측정 예정입니다.

## 참고사항 및 스크린샷(선택)

**eval 실행 방법**
```bash
uv run python scripts/evaluate.py --skill   # Skill Lab만
uv run python scripts/evaluate.py --all     # 전체
```

**비교 구조 (Gear Advisor 형식과 동일)**

| Metric | LLM-only | RAG Baseline | Delta |
|--------|----------|--------------|-------|
| Equipment Pass Rate | - | - | - |
| Time Pass Rate | - | - | - |

> 크레딧 충전 후 실측치로 채워질 예정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Evaluation system now compares LLM-only and retrieval-augmented coaching approaches side-by-side.
  * Separate pass rate metrics reported for each approach.

* **Tests**
  * Updated test suite to properly mock asynchronous evaluation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->