### PR TITLE
docs: README 전면 재작성 - 사실 기반 현행화

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,136 +1,73 @@
-<div align="center">
-  <img src="https://github.com/user-attachments/assets/24896d45-950b-4deb-a190-b5782f9b12c3" width="500" alt="assist_logo">
-  <br/>
-  <br/>
+# Assist — 농구인을 위한 AI 어시스턴트
 
-  <img src="https://img.shields.io/badge/Python-3.10+-3776AB?style=flat-square&logo=python&logoColor=white"/>
-  <img src="https://img.shields.io/badge/FastAPI-005571?style=flat-square&logo=fastapi&logoColor=white"/>
-  <img src="https://img.shields.io/badge/LangGraph-Agentic-orange?style=flat-square"/>
-  <img src="https://img.shields.io/badge/uv-Package%20Manager-blue?style=flat-square"/>
-  <img src="https://img.shields.io/badge/License-MIT-green?style=flat-square"/>
+훈련 루틴 생성, 주간 플랜, 농구화 추천, 룰 판정 — 네 기능을 각각 전용 LangGraph 에이전트로 구현한 FastAPI 백엔드입니다.
 
-  <br/>
-  
-  # Assist: AI-powered Basketball Partner
-  
-  <p>
-    <b>Assist</b> is an intelligent agent project that combines 'LangGraph' and 'RAG' technologies to help <b>hoopers</b> enhance their performance through data-driven insights.
-  </p>
-</div>
+**Live Demo: https://assist-frontend-plum.vercel.app**
+(무료 서버라 **첫 요청은 서버 기동으로 약 1분** 걸릴 수 있습니다. 한 번 뜨면 이후엔 즉시 응답합니다.)
 
-**🌐 Live Demo: [https://assist-frontend-plum.vercel.app](https://assist-frontend-plum.vercel.app)**
+## 무엇을 왜 만들었나
 
----
+혼자 운동하는 농구인은 전문 코칭에 접근하기 어렵습니다. "슛이 안 맞는데 뭘 연습해야 하지", "이 상황이 파울인가" 같은 질문에 근거 있는 답을 주는 도구를 목표로 했습니다.
 
-## 🏀 Introduction
-**'Assist'** is designed to bridge the information gap faced by **hoopers** by increasing the accessibility of professional coaching systems. The AI precisely analyzes a **hooper's** physical attributes and the context of their inquiries to provide an experience akin to having a personal coach standing right by the courtside.
+| 기능 | 에이전트 파이프라인 | 하는 일 |
+|---|---|---|
+| **AI Skill Lab** | `diagnose → generate` | 한 가지 기술을 3~5개 마이크로 스텝으로 분해한 훈련 카드 생성. 요청한 연습 시간에 맞춰 스텝 시간을 배분 |
+| **Weekly Routine** | `diagnose → plan_week → generate` | 1~7일 주간 훈련 플랜. LLM이 요일별 포커스를 배분(실패 시 라운드로빈 폴백) |
+| **Gear Advisor** | `analyze → retrieve → generate` | 감각 선호(쿠션감·접지력 등)와 플레이 스타일 기반 농구화 추천 — 신발 59켤레·선수 프로필 20건 벡터 검색, 예산 필터 |
+| **The Whistle** | `parse → extract_keywords → retrieve → generate` | 경기 상황을 룰 조문으로 판정 — FIBA·NBA 룰북을 조문 단위로 청킹해 검색, 용어집 22개 병행 |
 
-> "Basketball is a game of details. Assist helps **hoopers** master those details."
+모든 응답은 Pydantic 스키마로 강제되고, 파싱 실패 시 2단계 재시도를 거칩니다. JWT 인증(access+refresh)과 플랜 저장(SQLite/PostgreSQL)을 지원합니다.
 
----
+## 스택과 구조
 
-## 🚀 Key Features (MVP)
-This project implements four core features, each powered by a dedicated LangGraph agent with its own state machine workflow.
-
-### **1. AI Skill Lab (Personalized Skill Trainer)**
-* **Agent**: `CoachAgent` (`diagnose → retrieve → generate`)
-* **Definition**: A structured training generator that creates actionable **'Daily Routine Cards'** based on a **hooper's** specific weaknesses, position, and available time.
-* **Details**: Retrieves specific drills from a vector database (47 drills across shooting, dribble, defense, conditioning) and orchestrates them into a progressive workout session (Warm-up → Main Drills → Cool-down). Supports equipment-aware filtering to exclude drills requiring unavailable gear.
-
-### **2. Weekly Drill Routine (Weekly Training Planner)**
-* **Agent**: `WeeklyCoachAgent` (`diagnose → plan_week → retrieve → generate`)
-* **Definition**: An advanced training planner that generates **'Weekly Training Plans'** spanning 1-7 days, distributing multiple focus areas with recovery-aware scheduling.
-* **Details**: Intelligently allocates focus areas across training days via LLM-based planning with round-robin fallback, retrieves drills per day from the vector database, and generates custom drill variations (`is_custom: true`) when existing drills are insufficient.
-
-### **3. Gear Advisor (Sensory-based Recommendation)**
-* **Agent**: `GearAgent` (`analyze → retrieve → generate`)
-* **Definition**: A recommendation engine that matches basketball shoes based on **'Sensory Preferences'** (e.g., cushion feel, traction grip) and **'Player Archetypes'**.
-* **Details**: Cross-analyzes sensory tag embeddings, player archetype matching, and signature shoe boosting across 59 shoes and 20 player profiles. Supports budget filtering with dedicated `BudgetInsufficientError` handling.
-
-### **4. The Whistle (AI Referee & Rule Dictionary)**
-* **Agent**: `JudgeAgent` (`parse → retrieve → generate`)
-* **Definition**: An on-court dispute solver that provides authoritative judgments and clear definitions of complex basketball regulations (FIBA/NBA).
-* **Details**: Searches vectorized rulebooks (FIBA + NBA PDFs, article-level chunking) to cite specific articles for controversial plays and serves as an instant glossary (22 terms) for technical terminology. Includes 2-level JSON retry parsing for robust LLM output handling.
-
----
-
-## 🛠 Tech Stack
-The following technical ecosystem was established to ensure system stability and scalability for the **Assist** platform.
-
-| Category | Technology | Rationale |
-| :--- | :--- | :--- |
-| **Language** | **Python 3.10+** | Provides optimized compatibility with AI and data analysis libraries |
-| **Backend** | **FastAPI** | Implements high-performance API services through asynchronous processing |
-| **Frontend** | **Next.js 15 + Tailwind CSS** | Delivers a responsive UI with server-side rendering and utility-first styling |
-| **Orchestration** | **LangGraph** | Enables advanced agent control via state-based cyclic logic for multi-functional tasks |
-| **Vector DB** | **ChromaDB** | Supports rapid data embedding and efficient vector similarity search |
-| **Package/Quality**| **uv & Ruff** | Ensures ultra-fast dependency management and strict code standard compliance |
-
----
-
-## 🏗 System Architecture
-Each feature is served by a dedicated **LangGraph StateGraph agent** that follows a consistent multi-node pipeline pattern.
+Python · FastAPI · LangGraph · ChromaDB(벡터) · SQLAlchemy(SQLite/PostgreSQL) · JWT(python-jose)+bcrypt · uv/Ruff — 프론트엔드는 별도 레포(Next.js 15, Vercel 배포), 백엔드는 Render.
 
 ```
-[User Request]  →  [FastAPI Endpoint]  →  [Dedicated Agent Graph]
-                                                    │
-                                          ┌─────────┴─────────┐
-                                          │  Node 1: Parse/   │
-                                          │  Analyze Input    │
-                                          ├─────────┬─────────┤
-                                          │  Node 2: RAG      │
-                                          │  Retrieval        │
-                                          ├─────────┬─────────┤
-                                          │  Node 3: LLM      │
-                                          │  Generation       │
-                                          └─────────┬─────────┘
-                                                    │
-                                          [Pydantic Validated Response]
+[요청] → [FastAPI] → [기능별 LangGraph StateGraph]
+                        ① 입력 파싱·정제 (프롬프트 인젝션 패턴 차단)
+                        ② RAG 검색 (ChromaDB — 드릴·신발·선수·룰·용어집)
+                        ③ 스키마 강제 생성 (Pydantic + 재시도 파싱)
 ```
 
-1. **Input Parsing & Sanitization**: Each agent validates and sanitizes user input, including prompt injection pattern blocking.
-2. **Context Augmentation (RAG)**: Retrieves domain-specific knowledge from ChromaDB (drills, shoes, players, rules, glossary) with metadata filtering.
-3. **Structured Generation**: LLM generates responses constrained to Pydantic schemas, with retry logic for malformed outputs.
+The Whistle에는 `extract_keywords` 노드를 따로 뒀습니다 — 긴 상황 서술문과 짧은 룰 조문의 임베딩 공간이 어긋나 검색이 빗나가는 문제를, 상황문을 3~5개 위반 유형 키워드로 압축한 뒤 검색하는 방식으로 줄였습니다.
 
----
+## 평가 (2026-04-22 측정)
 
-## 📊 Performance Metrics
+LLM-as-Judge(gpt-4o) 파이프라인으로 기능별 25케이스를 채점했습니다. 아래는 당시 측정값이며, 이후 코드가 변경되어 현재 코드 기준으로 재측정된 값이 아닙니다.
 
-We employ an **LLM-as-Judge** evaluation pipeline (powered by `gpt-4o`) to assess the quality of our RAG responses against an expanded dataset of 50 challenging test cases (25 for Gear Advisor, 25 for The Whistle).
+| 기능 | Accuracy | Logical Consistency | 기타 |
+|---|---|---|---|
+| Gear Advisor (25케이스) | 3.56 / 5.0 | 4.20 / 5.0 | Data Fidelity 3.04 |
+| The Whistle (25케이스) | 3.40 / 5.0 | 3.52 / 5.0 | Citation Appropriateness 2.84 |
 
-### **1. Gear Advisor (Shoe Recommendation)**
-*Evaluated across 25 complex player archetype and budget constraint scenarios.*
-- **Accuracy:** 3.56 / 5.0
-- **Logical Consistency:** 4.20 / 5.0
-- **Data Fidelity:** 3.04 / 5.0
+평가 스크립트와 케이스 데이터셋은 `scripts/eval/`에 있습니다.
 
-### **2. The Whistle (Rule Judgment)**
-*Evaluated across 25 complex regulation scenarios including intentional fouls and violations.*
-- **Accuracy:** 3.40 / 5.0
-- **Logical Consistency:** 3.52 / 5.0
-- **Citation Appropriateness:** 2.84 / 5.0
+## 한계
 
----
+- **평가 수치는 LLM이 LLM을 채점한 값입니다.** 사람 검증을 거치지 않았고, 측정 시점 이후 코드 변경분이 반영되지 않았습니다.
+- **Whistle의 인용 적합성(2.84/5)이 가장 약합니다.** 판정은 그럴듯한데 근거 조문이 어긋나는 경우가 남아 있습니다.
+- **일부 통합 테스트가 로컬 벡터 DB 적재 상태에 의존합니다.** fresh clone에서 전부 통과하지 않습니다.
+- **무료 호스팅 콜드스타트** — 첫 요청 약 1분.
 
-## 💻 Getting Started
+## 배운 것
 
-### **Prerequisites**
-* Python 3.10 or higher
-* **uv** package manager installed
+- 기능마다 상태 머신(LangGraph)을 분리하면 프롬프트·검색·생성을 기능 단위로 독립 개선할 수 있습니다.
+- LLM 출력은 스키마로 강제하고 재시도를 설계해야 서비스가 됩니다 — 프롬프트만으로는 형식이 지켜지지 않았습니다.
+- 검색 품질은 임베딩 대상의 형태를 맞추는 것에서 갈렸습니다(상황문→키워드 압축).
+- 평가를 LLM-as-Judge에만 맡기면 수치의 근거를 설명하기 어렵다는 한계를 남겼습니다.
 
-### **Installation & Run**
+> 이 반성이 다음 프로젝트의 출발점이 됐습니다 — **[jd-gap-analyzer](https://github.com/zweadfx/jd-gap-analyzer)**: 판정 기준 사전 커밋, 사람 판정, 원문 대조 검증 등 측정·검증을 중심에 둔 후속 프로젝트.
+
+## 실행
+
 ```bash
-# 1. Clone the repository
 git clone https://github.com/zweadfx/assist.git
 cd assist
-
-# 2. Install dependencies and sync virtual environment
 uv sync
-
-# 3. Configure environment variables
-cp .env.example .env
-# Enter required keys such as OPENAI_API_KEY in the .env file
-
-# 4. Run the backend server
+cp .env.example .env   # OPENAI_API_KEY 등 입력
 uv run uvicorn src.main:app --reload
 ```
+
+Python 3.10+ · API 문서: 서버 기동 후 `/docs`
+
+라이선스: MIT


### PR DESCRIPTION
레포 실물과 대조해 재작성.

- 에이전트 파이프라인은 코드의 add_node 기준 (PR #110 내용 검증 후 반영)
- 평가 수치는 측정 시점(2026-04-22) 명시 형태로만 유지 — 재측정 아님을 문서에 명시
- 한계 정직 기술: LLM-as-Judge 순환, 인용 적합성 최약, 테스트의 로컬 상태 의존, 콜드스타트
- 배운 것 + 후속 프로젝트(jd-gap-analyzer) 링크 1줄
- 데모 콜드스타트 ~1분 안내, 이모지·과장 제거

참고: 머지 시 #110(기존 README 업데이트 PR)은 사실상 대체됨 — 처리는 소유자 판단.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Rewrote the README in Korean with a concise overview of the product’s four core capabilities.
  * Added simplified descriptions of system flow, technology stack, authentication, structured responses, and retry behavior.
  * Condensed performance metrics, limitations, lessons learned, and setup instructions.
  * Retained the MIT license information and added a link to a related follow-up project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->