### PR TITLE
docs: 평가 기록 정리 - 리포트 전량 커밋 + README 4/24 수치 통일

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,21 +31,25 @@ Python · FastAPI · LangGraph · ChromaDB(벡터) · SQLAlchemy(SQLite/PostgreS
 
 The Whistle에는 `extract_keywords` 노드를 따로 뒀습니다 — 긴 상황 서술문과 짧은 룰 조문의 임베딩 공간이 어긋나 검색이 빗나가는 문제를, 상황문을 3~5개 위반 유형 키워드로 압축한 뒤 검색하는 방식으로 줄였습니다.
 
-## 평가 (2026-04-22 측정)
+## 평가 (2026-04-24 측정)
 
-LLM-as-Judge(gpt-4o) 파이프라인으로 기능별 25케이스를 채점했습니다. 아래는 당시 측정값이며, 이후 코드가 변경되어 현재 코드 기준으로 재측정된 값이 아닙니다.
+규칙 기반 지표 + LLM-as-Judge(gpt-4o)로 기능별 채점했습니다. 4/22 1차 측정 후 **평가 자체를 재설계**(데이터셋 기대 조문 수정, Judge 프롬프트 도메인 분리, retrieval/generation 지표 분리)했기 때문에, 아래는 재설계 후 측정값이며 1차 수치와의 직접 비교(델타)는 하지 않습니다.
 
-| 기능 | Accuracy | Logical Consistency | 기타 |
+| 기능 | 지표 | 값 | 근거 리포트 |
 |---|---|---|---|
-| Gear Advisor (25케이스) | 3.56 / 5.0 | 4.20 / 5.0 | Data Fidelity 3.04 |
-| The Whistle (25케이스) | 3.40 / 5.0 | 3.52 / 5.0 | Citation Appropriateness 2.84 |
+| **The Whistle** (25케이스) | Rule Hit@3 / MRR | 0.56 / 0.46 | [20260424_091815](docs/eval/eval_report_20260424_091815.md) |
+| | Citation Hit Rate | 0.72 | 〃 |
+| | Accuracy / Citation / Faithfulness (Judge) | 4.68 / 4.40 / 4.76 (5.0 만점) | 〃 |
+| **Gear Advisor** (25케이스) | Hit@3 / MRR (RAG) | 0.92 / 0.87 | [20260424_093601](docs/eval/eval_report_20260424_093601.md) |
+| | Accuracy / Data Fidelity (Judge) | 4.36 / 4.76 (5.0 만점) | 〃 |
+| **Skill Lab** (5케이스, 2026-04-28) | 장비 준수율 / 시간 준수율 | 1.00 / 1.00 (RAG 베이스라인 0.80 / 1.00) | [20260428_230907](docs/eval/eval_report_20260428_230907.md) |
 
-평가 스크립트와 케이스 데이터셋은 `scripts/eval/`에 있습니다.
+**평가 여정** — 실패런 포함 전 리포트를 [docs/eval/](docs/eval/)에 그대로 커밋했습니다: 3/18 규칙 기반 1차는 id 매칭 버그로 전 지표 0.00([리포트](docs/eval/eval_report_20260318_151043.md)) → 같은 날 수정 후 Gear Hit@3 0.87([리포트](docs/eval/eval_report_20260318_151753.md)). 4/22 LLM-as-Judge 도입 — 스코어 파싱 실패런 2회 뒤 성공([리포트](docs/eval/eval_report_20260422_164143.md)). 4/23~24 평가 재설계 후 재측정한 것이 위 표입니다. 평가 스크립트와 케이스 데이터셋은 `scripts/eval/`에 있습니다.
 
 ## 한계
 
-- **평가 수치는 LLM이 LLM을 채점한 값입니다.** 사람 검증을 거치지 않았고, 측정 시점 이후 코드 변경분이 반영되지 않았습니다.
-- **Whistle의 인용 적합성(2.84/5)이 가장 약합니다.** 판정은 그럴듯한데 근거 조문이 어긋나는 경우가 남아 있습니다.
+- **Judge 수치는 LLM이 LLM을 채점한 값입니다.** 사람 검증을 거치지 않았고, 측정 시점 이후 코드 변경분이 반영되지 않았습니다.
+- **Whistle의 검색 지표가 가장 약합니다(Rule Hit@3 0.56 · MRR 0.46).** 생성 단계 지표는 높지만, 정답 조문이 상위 검색에 못 든 케이스가 절반 가까이 됩니다.
 - **일부 통합 테스트가 로컬 벡터 DB 적재 상태에 의존합니다.** fresh clone에서 전부 통과하지 않습니다.
 - **무료 호스팅 콜드스타트** — 첫 요청 약 1분.
 

--- a/docs/eval/eval_report_20260318_151043.md
+++ b/docs/eval/eval_report_20260318_151043.md
@@ -1,0 +1,72 @@
+# RAG Evaluation Report
+
+Generated: 2026-03-18 15:10:43
+
+---
+
+## Gear Advisor: RAG vs No-RAG Baseline
+
+| Metric | RAG | Baseline | Delta |
+|--------|-----|----------|-------|
+| Hit@3 | 0.00 | 0.00 | +0.00 |
+| MRR | 0.00 | 0.00 | +0.00 |
+| Cases | 15 | 15 | - |
+
+### Case Details
+
+| ID | Description | Expected | RAG Predicted | Baseline Predicted | RAG Hit | Baseline Hit |
+|----|-------------|----------|---------------|-------------------|---------|-------------|
+| gear-01 | Guard seeking Curry-style lightweight traction shoes | shoe_031 | 1, 2, 3 | Curry_12, Air_Zoom_G.T._Cut_3, Kobe_5_Protro | X | X |
+| gear-02 | Forward seeking LeBron-style cushioned stable shoes | shoe_009 | 1, 2, 3 | 1, 2, 3 | X | X |
+| gear-03 | Guard seeking Kobe-style court feel shoes | shoe_001, shoe_002, shoe_003 | 1, 2 | 1, 2, 3 | X | X |
+| gear-04 | Center seeking Jokic-style cushioned stable shoes | shoe_052 | 1, 2, 3 | Sabrina 1, Harden Vol. 7, Way of Wade 11 | X | X |
+| gear-05 | Traction and lightweight combination | shoe_001, shoe_002, shoe_003... | 1, 2, 3 | 1, 3, 2 | X | X |
+| gear-06 | Cushioning and stability combination | shoe_009, shoe_015, shoe_047... | NB_FreshFoamBBv2, Skechers_SKXReigns, Nike_PG6 | 1, 2, 3 | X | X |
+| gear-07 | Responsive and court feel combination | shoe_001, shoe_002, shoe_003... | Kobe_6_Protro, Kobe_5_Protro, KAI_2 | 1, 2, 3 | X | X |
+| gear-08 | Stability and traction with lockdown | shoe_005, shoe_006, shoe_046 | 1, 3, 5 | Nike-Air Zoom GT Cut 2, Nike-Sabrina 1, Nike-KD 15 | X | X |
+| gear-09 | Budget constraint 100K KRW | shoe_032, shoe_050 | under_armour_lockdown_6, skechers_skx_reigns | Lockdown 6-UA, Big3 5.0 Quick Pro-361, AR2-Rigorer | X | X |
+| gear-10 | Budget constraint 150K KRW with lightweight preference | shoe_016, shoe_025, shoe_026... | 1, 2, 3 | D.O.N. Issue 6, 361° Big3 5.0 Quick Pro, AE 1 | X | X |
+| gear-11 | Budget constraint 200K KRW with cushioning preference | shoe_009, shoe_047, shoe_053... | 1, 2 | Zoom Freak 5, KD 15, Sabrina 1 | X | X |
+| gear-12 | Position only - guard, no player archetype | shoe_001, shoe_002, shoe_003... | 1, 2, 3 | 1, 2, 3 | X | X |
+| gear-13 | Position only - center, no player archetype | shoe_009, shoe_015, shoe_019... | NB_FFBBv2, SK_SKR, NIKE_PG6 | Nike - LeBron XX, Nike - Luka 4, Li-Ning - Way of Wade 11 | X | X |
+| gear-14 | Complex: Damian Lillard style + guard + budget 180K | shoe_028, shoe_029 | adidas-dame-8, adidas-dame-9, newbalance-two-wxy-v4 | Dame_9, Dame_8, DON_7 | X | X |
+| gear-15 | Complex: Kyrie Irving style + guard + budget 160K + court feel | shoe_044, shoe_045 | 1, 2, 3 | Anta_KAI_2, Nike_Ja_2, Adidas_Dame_8 | X | X |
+
+---
+
+## Whistle: Citation Accuracy
+
+| Metric | Value |
+|--------|-------|
+| Citation Hit Rate | 0.00 |
+| Cases | 5 |
+
+### Case Details
+
+| ID | Description | Expected Decision | Predicted Decision | Match | Expected Articles | Predicted Articles |
+|----|-------------|-------------------|-------------------|-------|-------------------|-------------------|
+| whistle-01 | Player carries the ball while taking three steps without dribbling | violation | violation | O | 25 | Art 24 |
+| whistle-02 | Defender blocks driving player without established position | foul | foul | O | 33 | 33.9, 33.6 |
+| whistle-03 | Offensive player charges into set defender | foul | foul | O | 33 | Art 33 |
+| whistle-04 | Player stops dribble then dribbles again | violation | violation | O | 24 | Art 24 |
+| whistle-05 | Defender blocks a shot while the ball is descending toward the rim | violation | violation | O | 31 | Art 31 |
+
+---
+
+## Skill Lab: Constraint Compliance
+
+| Metric | Value |
+|--------|-------|
+| Equipment Pass Rate | 0.40 |
+| Time Pass Rate | 1.00 |
+| Cases | 5 |
+
+### Case Details
+
+| ID | Description | Equipment | Time | Steps |
+|----|-------------|-----------|------|-------|
+| skill-01 | Beginner dribble drill with ball only, 15 minutes | FAIL | PASS | Waist Wrap Warm-Up(3m), Stationary Crossover Practice(4m), Slow Motion Walk and Crossover(3m), Crossover with Speed(3m), Game Scenario: Defender React(2m) |
+| skill-02 | Intermediate shooting drill with ball and hoop, 20 minutes | PASS | PASS | Stationary Form Shooting(4m), Form Shooting with Ball(4m), Add Movement: Catch and Shoot(4m), Increase Speed: Quick Release(4m), Game Simulation Drill(4m) |
+| skill-03 | Advanced defense drill with no equipment, 10 minutes | FAIL | PASS | Basic Stance and Slide(2m), Hand Positioning Practice(2m), Footwork and Reaction(2m), Intercepting Drill(2m), Game Simulation Defense(2m) |
+| skill-04 | Beginner conditioning drill with ball and cones, 25 minutes | PASS | PASS | 기초 동적 스트레칭(5m), 기초 드리블 힐링진(5m), 코트 반 코트 스프린트(4m), 콘을 이용한 스피드 제한(6m), 모의 게임 체력 유지(5m) |
+| skill-05 | Intermediate dribble drill with full equipment, 30 minutes | FAIL | PASS | Footwork and Body Positioning(5m), Stationary Crossover Drill(10m), Cone Weave with Basic Crossover(6m), Crossover with Speed(5m), Game-Like Scenario(4m) |

--- a/docs/eval/eval_report_20260318_151753.md
+++ b/docs/eval/eval_report_20260318_151753.md
@@ -1,0 +1,72 @@
+# RAG Evaluation Report
+
+Generated: 2026-03-18 15:17:53
+
+---
+
+## Gear Advisor: RAG vs No-RAG Baseline
+
+| Metric | RAG | Baseline | Delta |
+|--------|-----|----------|-------|
+| Hit@3 | 0.87 | 0.87 | +0.00 |
+| MRR | 0.82 | 0.83 | -0.01 |
+| Cases | 15 | 15 | - |
+
+### Case Details
+
+| ID | Description | Expected | RAG Predicted | Baseline Predicted | RAG Hit | Baseline Hit |
+|----|-------------|----------|---------------|-------------------|---------|-------------|
+| gear-01 | Guard seeking Curry-style lightweight traction shoes | shoe_031 | shoe_031, shoe_057, shoe_001 | shoe_031, shoe_005, shoe_020 | O | O |
+| gear-02 | Forward seeking LeBron-style cushioned stable shoes | shoe_009 | shoe_009, shoe_015, shoe_047 | shoe_009, shoe_022, shoe_015 | O | O |
+| gear-03 | Guard seeking Kobe-style court feel shoes | shoe_001, shoe_002, shoe_003 | shoe_001, shoe_002, shoe_043 | shoe_001, shoe_002, shoe_003 | O | O |
+| gear-04 | Center seeking Jokic-style cushioned stable shoes | shoe_052 | shoe_052, shoe_047, shoe_050 | shoe_052, shoe_041, shoe_018 | O | O |
+| gear-05 | Traction and lightweight combination | shoe_001, shoe_002, shoe_003... | shoe_054, shoe_006, shoe_059 | shoe_001, shoe_002, shoe_003 | X | O |
+| gear-06 | Cushioning and stability combination | shoe_009, shoe_015, shoe_047... | shoe_047, shoe_017 | shoe_007, shoe_008, shoe_021 | O | X |
+| gear-07 | Responsive and court feel combination | shoe_001, shoe_002, shoe_003... | shoe_001, shoe_003, shoe_045 | shoe_001, shoe_002, shoe_003 | O | O |
+| gear-08 | Stability and traction with lockdown | shoe_005, shoe_006, shoe_046 | shoe_032, shoe_017, shoe_047 | shoe_005, shoe_006, shoe_007 | X | O |
+| gear-09 | Budget constraint 100K KRW | shoe_032, shoe_050 | shoe_032, shoe_050 | shoe_050, shoe_032 | O | O |
+| gear-10 | Budget constraint 150K KRW with lightweight preference | shoe_016, shoe_025, shoe_026... | shoe_043, shoe_033, shoe_051 | shoe_017, shoe_025, shoe_026 | O | O |
+| gear-11 | Budget constraint 200K KRW with cushioning preference | shoe_009, shoe_047, shoe_053... | shoe_059, shoe_047 | shoe_009, shoe_018, shoe_023 | O | O |
+| gear-12 | Position only - guard, no player archetype | shoe_001, shoe_002, shoe_003... | shoe_001, shoe_006, shoe_049 | shoe_001, shoe_003, shoe_005 | O | O |
+| gear-13 | Position only - center, no player archetype | shoe_009, shoe_015, shoe_019... | shoe_047, shoe_050, shoe_017 | shoe_007, shoe_023, shoe_018 | O | X |
+| gear-14 | Complex: Damian Lillard style + guard + budget 180K | shoe_028, shoe_029 | shoe_028, shoe_029, shoe_057 | shoe_028, shoe_029, shoe_025 | O | O |
+| gear-15 | Complex: Kyrie Irving style + guard + budget 160K + court feel | shoe_044, shoe_045 | shoe_044, shoe_045, shoe_028 | shoe_045, shoe_014, shoe_028 | O | O |
+
+---
+
+## Whistle: Citation Accuracy
+
+| Metric | Value |
+|--------|-------|
+| Citation Hit Rate | 0.80 |
+| Cases | 5 |
+
+### Case Details
+
+| ID | Description | Expected Decision | Predicted Decision | Match | Expected Articles | Predicted Articles |
+|----|-------------|-------------------|-------------------|-------|-------------------|-------------------|
+| whistle-01 | Player carries the ball while taking three steps without dribbling | violation | violation | O | 25 | 24 |
+| whistle-02 | Defender blocks driving player without established position | foul | foul | O | 33 | 33 |
+| whistle-03 | Offensive player charges into set defender | foul | foul | O | 33 | 33 |
+| whistle-04 | Player stops dribble then dribbles again | violation | violation | O | 24 | 24, 24 |
+| whistle-05 | Defender blocks a shot while the ball is descending toward the rim | violation | violation | O | 31 | 31 |
+
+---
+
+## Skill Lab: Constraint Compliance
+
+| Metric | Value |
+|--------|-------|
+| Equipment Pass Rate | 1.00 |
+| Time Pass Rate | 1.00 |
+| Cases | 5 |
+
+### Case Details
+
+| ID | Description | Equipment | Time | Steps |
+|----|-------------|-----------|------|-------|
+| skill-01 | Beginner dribble drill with ball only, 15 minutes | PASS | PASS | Ball Feeling Exercise(3m), Stationary Low Dribbles(4m), Crossover Dribble(3m), Walking Dribble(3m), Speed Walk Dribble(2m) |
+| skill-02 | Intermediate shooting drill with ball and hoop, 20 minutes | PASS | PASS | Stationary Form Focus(5m), Form Shooting(5m), Slow Catch and Shoot(5m), Catch and Shoot with Movement(5m) |
+| skill-03 | Advanced defense drill with no equipment, 10 minutes | PASS | PASS | Stationary Defensive Stance(2m), Basic Lateral Slides(2m), Quick Slide Intervals(2m), Reactive Slide Drill(2m), Game-Scenario Slides(2m) |
+| skill-04 | Beginner conditioning drill with ball and cones, 25 minutes | PASS | PASS | 기초 스트레칭 (정적)(5m), 다이나믹 스트레칭(5m), 콘 사이의 발 움직임 연습(5m), 농구 공 유지 상태(5m), 3/4 스프린트 훈련(5m) |
+| skill-05 | Intermediate dribble drill with full equipment, 30 minutes | PASS | PASS | Shadow Crossover(5m), Stationary Ball Control(5m), Cone Weave with Crossover(10m), Speed Crossovers(5m), Game Situation Simulation(5m) |

--- a/docs/eval/eval_report_20260422_160625.md
+++ b/docs/eval/eval_report_20260422_160625.md
@@ -1,0 +1,96 @@
+# RAG Evaluation Report
+
+Generated: 2026-04-22 16:06:25
+
+---
+
+## Gear Advisor: RAG vs No-RAG Baseline
+
+| Metric | RAG | Baseline | Delta |
+|--------|-----|----------|-------|
+| Hit@3 | 0.92 | 0.96 | -0.04 |
+| MRR | 0.87 | 0.85 | +0.02 |
+| Cases | 25 | 25 | - |
+
+### LLM Judge Metrics (RAG)
+
+- Accuracy: 0.00 / 5.0
+- Consistency: 0.00 / 5.0
+- Citation: 0.00 / 5.0
+
+### Case Details
+
+| ID | Description | Expected | RAG Predicted | Baseline Predicted | RAG Hit | Baseline Hit | LLM Judge |  # noqa: E501
+|----|-------------|----------|---------------|-------------------|---------|-------------|-----------|
+| gear-01 | Guard seeking Curry-style lightweight traction shoes | shoe_031 | shoe_031, shoe_001, shoe_049 | shoe_031, shoe_005, shoe_030 | O | O | A:0 C:0 Cit:0 |
+| gear-02 | Forward seeking LeBron-style cushioned stable shoes | shoe_009 | shoe_009, shoe_015 | shoe_009, shoe_022, shoe_015 | O | O | A:0 C:0 Cit:0 |
+| gear-03 | Guard seeking Kobe-style court feel shoes | shoe_001, shoe_002, shoe_003 | shoe_001, shoe_002, shoe_043 | shoe_001, shoe_003, shoe_002 | O | O | A:0 C:0 Cit:0 |
+| gear-04 | Center seeking Jokic-style cushioned stable shoes | shoe_052 | shoe_052, shoe_047, shoe_050 | shoe_052, shoe_007, shoe_018 | O | O | A:0 C:0 Cit:0 |
+| gear-05 | Traction and lightweight combination | shoe_001, shoe_002, shoe_003... | shoe_054, shoe_059 | shoe_001, shoe_002, shoe_003 | X | O | A:0 C:0 Cit:0 |
+| gear-06 | Cushioning and stability combination | shoe_009, shoe_015, shoe_047... | shoe_047, shoe_050, shoe_017 | shoe_007, shoe_008, shoe_009 | O | O | A:0 C:0 Cit:0 |
+| gear-07 | Responsive and court feel combination | shoe_001, shoe_002, shoe_003... | shoe_001, shoe_003, shoe_045 | shoe_001, shoe_002, shoe_003 | O | O | A:0 C:0 Cit:0 |
+| gear-08 | Stability and traction with lockdown | shoe_005, shoe_006, shoe_046 | shoe_032, shoe_017, shoe_048 | shoe_005, shoe_006, shoe_007 | X | O | A:0 C:0 Cit:0 |
+| gear-09 | Budget constraint 100K KRW | shoe_032, shoe_050 | shoe_032, shoe_050 | shoe_032, shoe_050 | O | O | A:0 C:0 Cit:0 |
+| gear-10 | Budget constraint 150K KRW with lightweight preference | shoe_016, shoe_025, shoe_026... | shoe_043, shoe_033, shoe_051 | shoe_025, shoe_026, shoe_051 | O | O | A:0 C:0 Cit:0 |
+| gear-11 | Budget constraint 200K KRW with cushioning preference | shoe_009, shoe_047, shoe_053... | shoe_059, shoe_047 | shoe_015, shoe_009, shoe_023 | O | O | A:0 C:0 Cit:0 |
+| gear-12 | Position only - guard, no player archetype | shoe_001, shoe_002, shoe_003... | shoe_057, shoe_001, shoe_006 | shoe_053, shoe_030, shoe_028 | O | X | A:0 C:0 Cit:0 |
+| gear-13 | Position only - center, no player archetype | shoe_009, shoe_015, shoe_019... | shoe_047, shoe_017 | shoe_007, shoe_018, shoe_009 | O | O | A:0 C:0 Cit:0 |
+| gear-14 | Complex: Damian Lillard style + guard + budget 180K | shoe_028, shoe_029 | shoe_028, shoe_029, shoe_057 | shoe_028, shoe_029, shoe_026 | O | O | A:0 C:0 Cit:0 |
+| gear-15 | Complex: Kyrie Irving style + guard + budget 160K + court feel | shoe_044, shoe_045 | shoe_044, shoe_045, shoe_028 | shoe_014, shoe_045, shoe_044 | O | O | A:0 C:0 Cit:0 |
+| gear-16 | Forward seeking Kawhi-style defensive lockdown with ankle support | shoe_048 | shoe_048, shoe_047, shoe_032 | shoe_048, shoe_009, shoe_015 | O | O | A:0 C:0 Cit:0 |
+| gear-17 | Forward seeking impact protection under 200K, no archetype | shoe_015, shoe_047, shoe_048... | shoe_059, shoe_047, shoe_015 | shoe_015, shoe_018, shoe_009 | O | O | A:0 C:0 Cit:0 |
+| gear-18 | Cheapest option under 80K for entry-level player | shoe_050 | shoe_050 | shoe_050, shoe_032 | O | O | A:0 C:0 Cit:0 |
+| gear-19 | Guard seeking James Harden style cushioning euro-step shoe | shoe_023, shoe_024 | shoe_023, shoe_024 | shoe_023, shoe_024, shoe_007 | O | O | A:0 C:0 Cit:0 |
+| gear-20 | Guard seeking Luka Doncic style step-back cushioning shoe | shoe_018, shoe_022 | shoe_022, shoe_018 | shoe_022, shoe_018, shoe_009 | O | O | A:0 C:0 Cit:0 |
+| gear-21 | Guard seeking Anthony Edwards style explosive responsive shoe | shoe_027 | shoe_027, shoe_001, shoe_057 | shoe_001, shoe_027, shoe_030 | O | O | A:0 C:0 Cit:0 |
+| gear-22 | Forward seeking Kevin Durant style lightweight balanced shoe | shoe_010, shoe_011, shoe_012 | shoe_010, shoe_011, shoe_053 | shoe_012, shoe_011, shoe_010 | O | O | A:0 C:0 Cit:0 |
+| gear-23 | Guard seeking Dwyane Wade style premium cushioning shoe | shoe_037, shoe_038 | shoe_037, shoe_038, shoe_050 | shoe_037, shoe_038, shoe_007 | O | O | A:0 C:0 Cit:0 |
+| gear-24 | Budget value pick under 150K for guard, no archetype preference | shoe_025, shoe_026, shoe_032... | shoe_051, shoe_056, shoe_049 | shoe_025, shoe_026, shoe_044 | O | O | A:0 C:0 Cit:0 |
+| gear-25 | Jayson Tatum style forward seeking all-around balanced shoe | shoe_021 | shoe_021, shoe_047, shoe_017 | shoe_021, shoe_007, shoe_018 | O | O | A:0 C:0 Cit:0 |
+
+---
+
+## Whistle: Citation Accuracy
+
+| Metric | Value |
+|--------|-------|
+| Citation Hit Rate | 0.44 |
+| Cases | 25 |
+
+### LLM Judge Metrics
+
+- Accuracy: 0.00 / 5.0
+- Consistency: 0.00 / 5.0
+- Citation: 0.00 / 5.0
+
+### Case Details
+
+| ID | Description | Expected Decision | Predicted Decision | Decision Match | Expected Articles | Predicted Articles | Citation Hit | LLM Judge |  # noqa: E501
+|----|-------------|-------------------|-------------------|----------------|-------------------|-------------------|--------------|-----------|  # noqa: E501
+| whistle-01 | Player carries the ball while taking three steps without dribbling | violation | violation | O | 25 | 13 | X | A:0 C:0 Cit:0 |
+| whistle-02 | Defender blocks driving player without established position | foul | foul | O | 33 | 33 | O | A:0 C:0 Cit:0 |
+| whistle-03 | Offensive player charges into set defender | foul | foul | O | 33 | 33 | O | A:0 C:0 Cit:0 |
+| whistle-04 | Player stops dribble then dribbles again | violation | violation | O | 24 | 24 | O | A:0 C:0 Cit:0 |
+| whistle-05 | Defender blocks a shot while the ball is descending toward the rim | violation | violation | O | 31 | 15 | X | A:0 C:0 Cit:0 |
+| whistle-06 | Offensive player remains in the paint for more than 3 seconds | violation | violation | O | 26 | 26 | O | A:0 C:0 Cit:0 |
+| whistle-07 | Team dribbles ball back into backcourt after establishing frontcourt | violation | violation | O | 28 | N/A | X | A:0 C:0 Cit:0 |
+| whistle-08 | Team fails to attempt a shot before the shot clock expires | violation | violation | O | 29 | 29 | O | A:0 C:0 Cit:0 |
+| whistle-09 | Legal two-step gather on euro step | legal | legal | O | 25 | 24 | X | A:0 C:0 Cit:0 |
+| whistle-10 | Player taunts an opponent after a dunk | foul | foul | O | 35 | 38 | X | A:0 C:0 Cit:0 |
+| whistle-11 | Defender grabs and pulls down a player with excessive force | foul | foul | O | 36 | 38 | X | A:0 C:0 Cit:0 |
+| whistle-12 | Screener moves into the path of defender at the last moment | foul | foul | O | 33 | 33 | O | A:0 C:0 Cit:0 |
+| whistle-13 | Taller player reaches over shorter player to grab a rebound | foul | foul | O | 33 | 24 | X | A:0 C:0 Cit:0 |
+| whistle-14 | NBA defender camps in the paint without guarding anyone | violation | violation | O | 10 | 10 | O | A:0 C:0 Cit:0 |
+| whistle-15 | Player fails to inbound the ball within 5 seconds | violation | violation | O | 27 | N/A | X | A:0 C:0 Cit:0 |
+| whistle-16 | Legal screen - defender runs into stationary screener | legal | legal | O | 33 | 33 | O | A:0 C:0 Cit:0 |
+| whistle-17 | Player intentionally kicks the ball to a teammate | violation | violation | O | 26 | Kickball | X | A:0 C:0 Cit:0 |
+| whistle-18 | Offensive player steps into the free throw lane before the ball hits the rim | violation | violation | O | 23 | 43 | X | A:0 C:0 Cit:0 |
+| whistle-19 | NBA player throws a punch at an opponent | foul | foul | O | 12 | 12 | O | A:0 C:0 Cit:0 |
+| whistle-20 | Deliberate foul to stop the clock near end of game | foul | foul | O | 33 | 29 | X | A:0 C:0 Cit:0 |
+| whistle-21 | Player steps out of bounds then re-enters and receives a pass | violation | violation | O | 23 | 23, 23 | O | A:0 C:0 Cit:0 |
+| whistle-22 | Shooter is fouled after releasing the ball - continuation play | foul | foul | O | 33 | 16 | X | A:0 C:0 Cit:0 |
+| whistle-23 | Player palms the ball during a dribble | violation | violation | O | 24 | 24 | O | A:0 C:0 Cit:0 |
+| whistle-24 | FIBA disqualifying foul - fighting on the court | foul | foul | O | 37 | 38, 39 | X | A:0 C:0 Cit:0 |
+| whistle-25 | Offensive basket interference - player touches ball above the cylinder | violation | violation | O | 31 | 15 | X | A:0 C:0 Cit:0 |
+
+---

--- a/docs/eval/eval_report_20260422_161950.md
+++ b/docs/eval/eval_report_20260422_161950.md
@@ -1,0 +1,96 @@
+# RAG Evaluation Report
+
+Generated: 2026-04-22 16:19:50
+
+---
+
+## Gear Advisor: RAG vs No-RAG Baseline
+
+| Metric | RAG | Baseline | Delta |
+|--------|-----|----------|-------|
+| Hit@3 | 0.92 | 0.96 | -0.04 |
+| MRR | 0.87 | 0.85 | +0.03 |
+| Cases | 25 | 25 | - |
+
+### LLM Judge Metrics (RAG)
+
+- Accuracy: 0.00 / 5.0
+- Consistency: 0.00 / 5.0
+- Citation: 0.00 / 5.0
+
+### Case Details
+
+| ID | Description | Expected | RAG Predicted | Baseline Predicted | RAG Hit | Baseline Hit | LLM Judge |  # noqa: E501
+|----|-------------|----------|---------------|-------------------|---------|-------------|-----------|
+| gear-01 | Guard seeking Curry-style lightweight traction shoes | shoe_031 | shoe_031, shoe_057, shoe_001 | shoe_031, shoe_005, shoe_014 | O | O | A:0 C:0 Cit:0 |
+| gear-02 | Forward seeking LeBron-style cushioned stable shoes | shoe_009 | shoe_009, shoe_015 | shoe_009, shoe_046, shoe_015 | O | O | A:0 C:0 Cit:0 |
+| gear-03 | Guard seeking Kobe-style court feel shoes | shoe_001, shoe_002, shoe_003 | shoe_001, shoe_002, shoe_043 | shoe_001, shoe_003, shoe_002 | O | O | A:0 C:0 Cit:0 |
+| gear-04 | Center seeking Jokic-style cushioned stable shoes | shoe_052 | shoe_052, shoe_047, shoe_050 | shoe_052, shoe_007, shoe_018 | O | O | A:0 C:0 Cit:0 |
+| gear-05 | Traction and lightweight combination | shoe_001, shoe_002, shoe_003... | shoe_006, shoe_053, shoe_054 | shoe_001, shoe_002, shoe_003 | X | O | A:0 C:0 Cit:0 |
+| gear-06 | Cushioning and stability combination | shoe_009, shoe_015, shoe_047... | shoe_047, shoe_017, shoe_050 | shoe_007, shoe_008, shoe_009 | O | O | A:0 C:0 Cit:0 |
+| gear-07 | Responsive and court feel combination | shoe_001, shoe_002, shoe_003... | shoe_001, shoe_003, shoe_045 | shoe_031, shoe_020, shoe_055 | O | O | A:0 C:0 Cit:0 |
+| gear-08 | Stability and traction with lockdown | shoe_005, shoe_006, shoe_046 | shoe_017, shoe_032, shoe_047 | shoe_007, shoe_046, shoe_017 | X | O | A:0 C:0 Cit:0 |
+| gear-09 | Budget constraint 100K KRW | shoe_032, shoe_050 | shoe_032, shoe_050 | shoe_032, shoe_049, shoe_050 | O | O | A:0 C:0 Cit:0 |
+| gear-10 | Budget constraint 150K KRW with lightweight preference | shoe_016, shoe_025, shoe_026... | shoe_043, shoe_033, shoe_051 | shoe_025, shoe_026, shoe_051 | O | O | A:0 C:0 Cit:0 |
+| gear-11 | Budget constraint 200K KRW with cushioning preference | shoe_009, shoe_047, shoe_053... | shoe_059, shoe_047 | shoe_007, shoe_008, shoe_009 | O | O | A:0 C:0 Cit:0 |
+| gear-12 | Position only - guard, no player archetype | shoe_001, shoe_002, shoe_003... | shoe_057, shoe_001, shoe_006 | shoe_001, shoe_005, shoe_028 | O | O | A:0 C:0 Cit:0 |
+| gear-13 | Position only - center, no player archetype | shoe_009, shoe_015, shoe_019... | shoe_047, shoe_017, shoe_050 | shoe_007, shoe_009, shoe_018 | O | O | A:0 C:0 Cit:0 |
+| gear-14 | Complex: Damian Lillard style + guard + budget 180K | shoe_028, shoe_029 | shoe_028, shoe_029, shoe_057 | shoe_028, shoe_029, shoe_027 | O | O | A:0 C:0 Cit:0 |
+| gear-15 | Complex: Kyrie Irving style + guard + budget 160K + court feel | shoe_044, shoe_045 | shoe_044, shoe_045, shoe_028 | shoe_044, shoe_045, shoe_028 | O | O | A:0 C:0 Cit:0 |
+| gear-16 | Forward seeking Kawhi-style defensive lockdown with ankle support | shoe_048 | shoe_048, shoe_047 | shoe_048, shoe_009, shoe_015 | O | O | A:0 C:0 Cit:0 |
+| gear-17 | Forward seeking impact protection under 200K, no archetype | shoe_015, shoe_047, shoe_048... | shoe_059, shoe_047, shoe_015 | shoe_018, shoe_010, shoe_007 | O | X | A:0 C:0 Cit:0 |
+| gear-18 | Cheapest option under 80K for entry-level player | shoe_050 | shoe_050 | shoe_050, shoe_032 | O | O | A:0 C:0 Cit:0 |
+| gear-19 | Guard seeking James Harden style cushioning euro-step shoe | shoe_023, shoe_024 | shoe_023, shoe_024 | shoe_023, shoe_024, shoe_007 | O | O | A:0 C:0 Cit:0 |
+| gear-20 | Guard seeking Luka Doncic style step-back cushioning shoe | shoe_018, shoe_022 | shoe_022, shoe_018 | shoe_018, shoe_022, shoe_009 | O | O | A:0 C:0 Cit:0 |
+| gear-21 | Guard seeking Anthony Edwards style explosive responsive shoe | shoe_027 | shoe_027, shoe_057, shoe_001 | shoe_027, shoe_005, shoe_031 | O | O | A:0 C:0 Cit:0 |
+| gear-22 | Forward seeking Kevin Durant style lightweight balanced shoe | shoe_010, shoe_011, shoe_012 | shoe_010, shoe_011, shoe_053 | shoe_012, shoe_011, shoe_010 | O | O | A:0 C:0 Cit:0 |
+| gear-23 | Guard seeking Dwyane Wade style premium cushioning shoe | shoe_037, shoe_038 | shoe_037, shoe_038 | shoe_037, shoe_041, shoe_007 | O | O | A:0 C:0 Cit:0 |
+| gear-24 | Budget value pick under 150K for guard, no archetype preference | shoe_025, shoe_026, shoe_032... | shoe_051, shoe_056, shoe_049 | shoe_025, shoe_026, shoe_027 | O | O | A:0 C:0 Cit:0 |
+| gear-25 | Jayson Tatum style forward seeking all-around balanced shoe | shoe_021 | shoe_021, shoe_047, shoe_017 | shoe_021, shoe_007, shoe_047 | O | O | A:0 C:0 Cit:0 |
+
+---
+
+## Whistle: Citation Accuracy
+
+| Metric | Value |
+|--------|-------|
+| Citation Hit Rate | 0.48 |
+| Cases | 25 |
+
+### LLM Judge Metrics
+
+- Accuracy: 0.00 / 5.0
+- Consistency: 0.00 / 5.0
+- Citation: 0.00 / 5.0
+
+### Case Details
+
+| ID | Description | Expected Decision | Predicted Decision | Decision Match | Expected Articles | Predicted Articles | Citation Hit | LLM Judge |  # noqa: E501
+|----|-------------|-------------------|-------------------|----------------|-------------------|-------------------|--------------|-----------|  # noqa: E501
+| whistle-01 | Player carries the ball while taking three steps without dribbling | violation | violation | O | 25 | 13 | X | A:0 C:0 Cit:0 |
+| whistle-02 | Defender blocks driving player without established position | foul | foul | O | 33 | 33 | O | A:0 C:0 Cit:0 |
+| whistle-03 | Offensive player charges into set defender | foul | foul | O | 33 | 33 | O | A:0 C:0 Cit:0 |
+| whistle-04 | Player stops dribble then dribbles again | violation | violation | O | 24 | 24 | O | A:0 C:0 Cit:0 |
+| whistle-05 | Defender blocks a shot while the ball is descending toward the rim | violation | violation | O | 31 | 15 | X | A:0 C:0 Cit:0 |
+| whistle-06 | Offensive player remains in the paint for more than 3 seconds | violation | violation | O | 26 | 26 | O | A:0 C:0 Cit:0 |
+| whistle-07 | Team dribbles ball back into backcourt after establishing frontcourt | violation | violation | O | 28 | N/A | X | A:0 C:0 Cit:0 |
+| whistle-08 | Team fails to attempt a shot before the shot clock expires | violation | violation | O | 29 | 29 | O | A:0 C:0 Cit:0 |
+| whistle-09 | Legal two-step gather on euro step | legal | legal | O | 25 | 24 | X | A:0 C:0 Cit:0 |
+| whistle-10 | Player taunts an opponent after a dunk | foul | foul | O | 35 | 38 | X | A:0 C:0 Cit:0 |
+| whistle-11 | Defender grabs and pulls down a player with excessive force | foul | foul | O | 36 | 38 | X | A:0 C:0 Cit:0 |
+| whistle-12 | Screener moves into the path of defender at the last moment | foul | foul | O | 33 | 33 | O | A:0 C:0 Cit:0 |
+| whistle-13 | Taller player reaches over shorter player to grab a rebound | foul | foul | O | 33 | N/A | X | A:0 C:0 Cit:0 |
+| whistle-14 | NBA defender camps in the paint without guarding anyone | violation | violation | O | 10 | 10 | O | A:0 C:0 Cit:0 |
+| whistle-15 | Player fails to inbound the ball within 5 seconds | violation | violation | O | 27 | 27 | O | A:0 C:0 Cit:0 |
+| whistle-16 | Legal screen - defender runs into stationary screener | legal | legal | O | 33 | 33 | O | A:0 C:0 Cit:0 |
+| whistle-17 | Player intentionally kicks the ball to a teammate | violation | violation | O | 26 | N/A | X | A:0 C:0 Cit:0 |
+| whistle-18 | Offensive player steps into the free throw lane before the ball hits the rim | violation | violation | O | 23 | 43 | X | A:0 C:0 Cit:0 |
+| whistle-19 | NBA player throws a punch at an opponent | foul | foul | O | 12 | 12 | O | A:0 C:0 Cit:0 |
+| whistle-20 | Deliberate foul to stop the clock near end of game | foul | foul | O | 33 | 29 | X | A:0 C:0 Cit:0 |
+| whistle-21 | Player steps out of bounds then re-enters and receives a pass | violation | violation | O | 23 | 23 | O | A:0 C:0 Cit:0 |
+| whistle-22 | Shooter is fouled after releasing the ball - continuation play | foul | foul | O | 33 | 16 | X | A:0 C:0 Cit:0 |
+| whistle-23 | Player palms the ball during a dribble | violation | violation | O | 24 | 24 | O | A:0 C:0 Cit:0 |
+| whistle-24 | FIBA disqualifying foul - fighting on the court | foul | foul | O | 37 | 38, 39 | X | A:0 C:0 Cit:0 |
+| whistle-25 | Offensive basket interference - player touches ball above the cylinder | violation | violation | O | 31 | N/A | X | A:0 C:0 Cit:0 |
+
+---

--- a/docs/eval/eval_report_20260422_164143.md
+++ b/docs/eval/eval_report_20260422_164143.md
@@ -1,0 +1,96 @@
+# RAG Evaluation Report
+
+Generated: 2026-04-22 16:41:43
+
+---
+
+## Gear Advisor: RAG vs No-RAG Baseline
+
+| Metric | RAG | Baseline | Delta |
+|--------|-----|----------|-------|
+| Hit@3 | 0.92 | 1.00 | -0.08 |
+| MRR | 0.89 | 0.90 | -0.01 |
+| Cases | 25 | 25 | - |
+
+### LLM Judge Metrics (RAG)
+
+- Accuracy: 3.56 / 5.0
+- Consistency: 4.20 / 5.0
+- Citation: 3.04 / 5.0
+
+### Case Details
+
+| ID | Description | Expected | RAG Predicted | Baseline Predicted | RAG Hit | Baseline Hit | LLM Judge |  # noqa: E501
+|----|-------------|----------|---------------|-------------------|---------|-------------|-----------|
+| gear-01 | Guard seeking Curry-style lightweight traction shoes | shoe_031 | shoe_031, shoe_057, shoe_001 | shoe_031, shoe_005, shoe_030 | O | O | A:4 C:5 Cit:4 |
+| gear-02 | Forward seeking LeBron-style cushioned stable shoes | shoe_009 | shoe_009, shoe_015, shoe_047 | shoe_009, shoe_015, shoe_048 | O | O | A:3 C:4 Cit:3 |
+| gear-03 | Guard seeking Kobe-style court feel shoes | shoe_001, shoe_002, shoe_003 | shoe_001, shoe_002, shoe_043 | shoe_001, shoe_002, shoe_003 | O | O | A:4 C:5 Cit:4 |
+| gear-04 | Center seeking Jokic-style cushioned stable shoes | shoe_052 | shoe_052, shoe_047, shoe_050 | shoe_052, shoe_009, shoe_023 | O | O | A:4 C:5 Cit:4 |
+| gear-05 | Traction and lightweight combination | shoe_001, shoe_002, shoe_003... | shoe_054, shoe_006, shoe_059 | shoe_001, shoe_002, shoe_003 | X | O | A:3 C:4 Cit:2 |
+| gear-06 | Cushioning and stability combination | shoe_009, shoe_015, shoe_047... | shoe_047, shoe_050, shoe_017 | shoe_007, shoe_008, shoe_009 | O | O | A:2 C:3 Cit:1 |
+| gear-07 | Responsive and court feel combination | shoe_001, shoe_002, shoe_003... | shoe_001, shoe_003, shoe_045 | shoe_001, shoe_003, shoe_005 | O | O | A:3 C:4 Cit:2 |
+| gear-08 | Stability and traction with lockdown | shoe_005, shoe_006, shoe_046 | shoe_032, shoe_017, shoe_048 | shoe_005, shoe_006, shoe_007 | X | O | A:2 C:3 Cit:2 |
+| gear-09 | Budget constraint 100K KRW | shoe_032, shoe_050 | shoe_032, shoe_050 | shoe_032, shoe_051, shoe_050 | O | O | A:3 C:4 Cit:2 |
+| gear-10 | Budget constraint 150K KRW with lightweight preference | shoe_016, shoe_025, shoe_026... | shoe_043, shoe_033, shoe_051 | shoe_025, shoe_026, shoe_027 | O | O | A:3 C:4 Cit:2 |
+| gear-11 | Budget constraint 200K KRW with cushioning preference | shoe_009, shoe_047, shoe_053... | shoe_059, shoe_047 | shoe_009, shoe_047, shoe_052 | O | O | A:3 C:4 Cit:2 |
+| gear-12 | Position only - guard, no player archetype | shoe_001, shoe_002, shoe_003... | shoe_006, shoe_001, shoe_057 | shoe_001, shoe_005, shoe_028 | O | O | A:3 C:4 Cit:2 |
+| gear-13 | Position only - center, no player archetype | shoe_009, shoe_015, shoe_019... | shoe_047, shoe_017, shoe_050 | shoe_007, shoe_023, shoe_052 | O | O | A:2 C:3 Cit:1 |
+| gear-14 | Complex: Damian Lillard style + guard + budget 180K | shoe_028, shoe_029 | shoe_028, shoe_029, shoe_057 | shoe_028, shoe_029, shoe_025 | O | O | A:4 C:4 Cit:3 |
+| gear-15 | Complex: Kyrie Irving style + guard + budget 160K + court feel | shoe_044, shoe_045 | shoe_044, shoe_045 | shoe_045, shoe_044, shoe_029 | O | O | A:5 C:5 Cit:5 |
+| gear-16 | Forward seeking Kawhi-style defensive lockdown with ankle support | shoe_048 | shoe_048, shoe_047, shoe_032 | shoe_009, shoe_048, shoe_015 | O | O | A:4 C:4 Cit:3 |
+| gear-17 | Forward seeking impact protection under 200K, no archetype | shoe_015, shoe_047, shoe_048... | shoe_059, shoe_047, shoe_015 | shoe_015, shoe_007, shoe_021 | O | O | A:3 C:4 Cit:2 |
+| gear-18 | Cheapest option under 80K for entry-level player | shoe_050 | shoe_050 | shoe_050 | O | O | A:5 C:5 Cit:5 |
+| gear-19 | Guard seeking James Harden style cushioning euro-step shoe | shoe_023, shoe_024 | shoe_024, shoe_023, shoe_050 | shoe_023, shoe_024, shoe_007 | O | O | A:5 C:5 Cit:5 |
+| gear-20 | Guard seeking Luka Doncic style step-back cushioning shoe | shoe_018, shoe_022 | shoe_022, shoe_018 | shoe_022, shoe_018, shoe_009 | O | O | A:5 C:5 Cit:5 |
+| gear-21 | Guard seeking Anthony Edwards style explosive responsive shoe | shoe_027 | shoe_027, shoe_001, shoe_057 | shoe_001, shoe_005, shoe_027 | O | O | A:4 C:4 Cit:3 |
+| gear-22 | Forward seeking Kevin Durant style lightweight balanced shoe | shoe_010, shoe_011, shoe_012 | shoe_010, shoe_011, shoe_053 | shoe_012, shoe_011, shoe_010 | O | O | A:3 C:4 Cit:3 |
+| gear-23 | Guard seeking Dwyane Wade style premium cushioning shoe | shoe_037, shoe_038 | shoe_037, shoe_038, shoe_051 | shoe_037, shoe_038, shoe_041 | O | O | A:4 C:4 Cit:4 |
+| gear-24 | Budget value pick under 150K for guard, no archetype preference | shoe_025, shoe_026, shoe_032... | shoe_051, shoe_056, shoe_049 | shoe_025, shoe_026, shoe_043 | O | O | A:3 C:4 Cit:2 |
+| gear-25 | Jayson Tatum style forward seeking all-around balanced shoe | shoe_021 | shoe_021, shoe_047, shoe_017 | shoe_021, shoe_007, shoe_041 | O | O | A:5 C:5 Cit:5 |
+
+---
+
+## Whistle: Citation Accuracy
+
+| Metric | Value |
+|--------|-------|
+| Citation Hit Rate | 0.28 |
+| Cases | 25 |
+
+### LLM Judge Metrics
+
+- Accuracy: 3.40 / 5.0
+- Consistency: 3.52 / 5.0
+- Citation: 2.84 / 5.0
+
+### Case Details
+
+| ID | Description | Expected Decision | Predicted Decision | Decision Match | Expected Articles | Predicted Articles | Citation Hit | LLM Judge |  # noqa: E501
+|----|-------------|-------------------|-------------------|----------------|-------------------|-------------------|--------------|-----------|  # noqa: E501
+| whistle-01 | Player carries the ball while taking three steps without dribbling | violation | violation | O | 25 | 13 | X | A:4 C:4 Cit:3 |
+| whistle-02 | Defender blocks driving player without established position | foul | foul | O | 33 | 33 | O | A:0 C:0 Cit:0 |
+| whistle-03 | Offensive player charges into set defender | foul | error | X | 33 | - | X | A:0 C:0 Cit:0 |
+| whistle-04 | Player stops dribble then dribbles again | violation | error | X | 24 | - | X | A:0 C:0 Cit:0 |
+| whistle-05 | Defender blocks a shot while the ball is descending toward the rim | violation | error | X | 31 | - | X | A:0 C:0 Cit:0 |
+| whistle-06 | Offensive player remains in the paint for more than 3 seconds | violation | error | X | 26 | - | X | A:0 C:0 Cit:0 |
+| whistle-07 | Team dribbles ball back into backcourt after establishing frontcourt | violation | error | X | 28 | - | X | A:0 C:0 Cit:0 |
+| whistle-08 | Team fails to attempt a shot before the shot clock expires | violation | error | X | 29 | - | X | A:5 C:5 Cit:5 |
+| whistle-09 | Legal two-step gather on euro step | legal | legal | O | 25 | 24 | X | A:4 C:4 Cit:3 |
+| whistle-10 | Player taunts an opponent after a dunk | foul | foul | O | 35 | 38 | X | A:3 C:4 Cit:3 |
+| whistle-11 | Defender grabs and pulls down a player with excessive force | foul | foul | O | 36 | 38 | X | A:4 C:5 Cit:4 |
+| whistle-12 | Screener moves into the path of defender at the last moment | foul | foul | O | 33 | 33 | O | A:5 C:5 Cit:5 |
+| whistle-13 | Taller player reaches over shorter player to grab a rebound | foul | foul | O | 33 | 15 | X | A:5 C:5 Cit:2 |
+| whistle-14 | NBA defender camps in the paint without guarding anyone | violation | violation | O | 10 | 10 | O | A:5 C:5 Cit:5 |
+| whistle-15 | Player fails to inbound the ball within 5 seconds | violation | violation | O | 27 | N/A | X | A:4 C:4 Cit:3 |
+| whistle-16 | Legal screen - defender runs into stationary screener | legal | legal | O | 33 | 33 | O | A:5 C:5 Cit:5 |
+| whistle-17 | Player intentionally kicks the ball to a teammate | violation | violation | O | 26 | N/A | X | A:5 C:5 Cit:3 |
+| whistle-18 | Offensive player steps into the free throw lane before the ball hits the rim | violation | violation | O | 23 | 43 | X | A:5 C:5 Cit:5 |
+| whistle-19 | NBA player throws a punch at an opponent | foul | foul | O | 12 | 12 | O | A:5 C:5 Cit:4 |
+| whistle-20 | Deliberate foul to stop the clock near end of game | foul | foul | O | 33 | 8 | X | A:4 C:4 Cit:3 |
+| whistle-21 | Player steps out of bounds then re-enters and receives a pass | violation | violation | O | 23 | 23 | O | A:5 C:5 Cit:5 |
+| whistle-22 | Shooter is fouled after releasing the ball - continuation play | foul | foul | O | 33 | 16 | X | A:4 C:5 Cit:3 |
+| whistle-23 | Player palms the ball during a dribble | violation | violation | O | 24 | 24 | O | A:5 C:5 Cit:5 |
+| whistle-24 | FIBA disqualifying foul - fighting on the court | foul | foul | O | 37 | 38 | X | A:4 C:4 Cit:3 |
+| whistle-25 | Offensive basket interference - player touches ball above the cylinder | violation | violation | O | 31 | 13 | X | A:4 C:4 Cit:2 |
+
+---

--- a/docs/eval/eval_report_20260424_091815.md
+++ b/docs/eval/eval_report_20260424_091815.md
@@ -1,0 +1,56 @@
+# RAG Evaluation Report
+
+Generated: 2026-04-24 09:18:15
+
+---
+
+## Whistle: RAG Evaluation
+
+### [1. Retrieval] DB가 문서를 잘 찾는가?
+
+| Metric | Value |
+|--------|-------|
+| Rule Hit@3 | 0.56 |
+| Rule MRR | 0.46 |
+| Cases | 25 |
+
+### [2. Generation] LLM이 답변을 잘 만드는가?
+
+| Metric | Value |
+|--------|-------|
+| Citation Hit Rate (Rule-based) | 0.72 |
+| Accuracy (LLM Judge) | 4.68 / 5.0 |
+| Citation (LLM Judge) | 4.40 / 5.0 |
+| Faithfulness (LLM Judge) | 4.76 / 5.0 |
+
+### Case Details
+
+| ID | Description | Expected | Predicted | Match | Retrieved | Cited | Cit Hit | LLM Judge |
+|----|-------------|----------|-----------|-------|-----------|-------|---------|-----------|
+| whistle-01 | Player carries the ball while taking three steps without dribbling | violation | violation | O | 2, 24, 25 | 25 | O | A:5 C:5 F:5 |
+| whistle-02 | Defender blocks driving player without established position | foul | foul | O | 41, 35, 34 | 33 | O | A:3 C:2 F:3 |
+| whistle-03 | Offensive player charges into set defender | foul | foul | O | 33, 34, 41 | 33 | O | A:5 C:5 F:5 |
+| whistle-04 | Player stops dribble then dribbles again | violation | violation | O | 22, 24, 43 | 24 | O | A:5 C:4 F:5 |
+| whistle-05 | Defender blocks a shot while the ball is descending toward the rim | violation | violation | O | 31, 39, 22 | 31 | O | A:5 C:5 F:5 |
+| whistle-06 | Offensive player remains in the paint for more than 3 seconds | violation | violation | O | 31, 22, 2 | 26 | O | A:5 C:5 F:5 |
+| whistle-07 | Team dribbles ball back into backcourt after establishing frontcourt | violation | violation | O | 25, 2, 24 | 30 | O | A:5 C:5 F:5 |
+| whistle-08 | Team fails to attempt a shot before the shot clock expires | violation | violation | O | 29, 26, 50 | 29, 29 | O | A:5 C:5 F:5 |
+| whistle-09 | Legal two-step gather on euro step | legal | legal | O | 33, 4, 25 | 25 | O | A:5 C:5 F:5 |
+| whistle-10 | Player taunts an opponent after a dunk | foul | violation | X | 50, 36, 34 | 36 | O | A:4 C:5 F:5 |
+| whistle-11 | Defender grabs and pulls down a player with excessive force | foul | foul | O | 33, 34, 37 | 37, 37 | O | A:5 C:5 F:5 |
+| whistle-12 | Screener moves into the path of defender at the last moment | foul | foul | O | 41, 34, 35 | 34 | X | A:5 C:4 F:5 |
+| whistle-13 | Taller player reaches over shorter player to grab a rebound | foul | foul | O | 35, 29, 32 | 33 | O | A:5 C:5 F:5 |
+| whistle-14 | NBA defender camps in the paint without guarding anyone | violation | violation | O | 10, 7 | 10 | O | A:5 C:5 F:5 |
+| whistle-15 | Player fails to inbound the ball within 5 seconds | violation | violation | O | 22, 31, 26 | 22 | X | A:5 C:3 F:4 |
+| whistle-16 | Legal screen - defender runs into stationary screener | legal | legal | O | 33, 32, 50 | 33 | O | A:5 C:5 F:5 |
+| whistle-17 | Player intentionally kicks the ball to a teammate | violation | violation | O | 22, 10, 33 | 13 | O | A:5 C:5 F:5 |
+| whistle-18 | Offensive player steps into the free throw lane before the ball hits the rim | violation | violation | O | 22, 31, 13 | 43 | O | A:5 C:4 F:5 |
+| whistle-19 | NBA player throws a punch at an opponent | foul | foul | O | 14, 4, 6 | 12 | X | A:5 C:5 F:5 |
+| whistle-20 | Deliberate foul to stop the clock near end of game | foul | foul | O | 33, 37, 32 | 37 | X | A:3 C:4 F:4 |
+| whistle-21 | Player steps out of bounds then re-enters and receives a pass | violation | violation | O | 22, 39, 31 | 22 | X | A:5 C:4 F:5 |
+| whistle-22 | Shooter is fouled after releasing the ball - continuation play | foul | foul | O | 37, 33, 32 | 34, 37 | X | A:5 C:4 F:5 |
+| whistle-23 | Player palms the ball during a dribble | violation | violation | O | 24, 2, 35 | 24 | O | A:3 C:2 F:3 |
+| whistle-24 | FIBA disqualifying foul - fighting on the court | foul | foul | O | 33, 34, 37 | 37 | X | A:4 C:4 F:5 |
+| whistle-25 | Offensive basket interference - player touches ball above the cylinder | violation | violation | O | 22, 16, 31 | 31 | O | A:5 C:5 F:5 |
+
+---

--- a/docs/eval/eval_report_20260424_093601.md
+++ b/docs/eval/eval_report_20260424_093601.md
@@ -1,0 +1,50 @@
+# RAG Evaluation Report
+
+Generated: 2026-04-24 09:36:01
+
+---
+
+## Gear Advisor: RAG vs No-RAG Baseline
+
+| Metric | RAG | Baseline | Delta |
+|--------|-----|----------|-------|
+| Hit@3 | 0.92 | 1.00 | -0.08 |
+| MRR | 0.87 | 0.91 | -0.03 |
+| Cases | 25 | 25 | - |
+
+### LLM Judge Metrics (RAG)
+
+- Accuracy: 4.36 / 5.0
+- Data Fidelity: 4.76 / 5.0
+
+### Case Details
+
+| ID | Description | Expected | RAG Predicted | Baseline Predicted | RAG Hit | Baseline Hit | LLM Judge |
+|----|-------------|----------|---------------|-------------------|---------|-------------|-----------|
+| gear-01 | Guard seeking Curry-style lightweight traction shoes | shoe_031 | shoe_031, shoe_057, shoe_001 | shoe_031, shoe_005, shoe_001 | O | O | A:4 Cit:5 |
+| gear-02 | Forward seeking LeBron-style cushioned stable shoes | shoe_009 | shoe_009, shoe_015, shoe_047 | shoe_009, shoe_015, shoe_022 | O | O | A:5 Cit:5 |
+| gear-03 | Guard seeking Kobe-style court feel shoes | shoe_001, shoe_002, shoe_003 | shoe_001, shoe_002, shoe_043 | shoe_001, shoe_002, shoe_003 | O | O | A:5 Cit:5 |
+| gear-04 | Center seeking Jokic-style cushioned stable shoes | shoe_052 | shoe_052, shoe_047, shoe_050 | shoe_052, shoe_007, shoe_021 | O | O | A:5 Cit:5 |
+| gear-05 | Traction and lightweight combination | shoe_001, shoe_002, shoe_003... | shoe_053, shoe_054, shoe_006 | shoe_001, shoe_002, shoe_003 | X | O | A:3 Cit:4 |
+| gear-06 | Cushioning and stability combination | shoe_009, shoe_015, shoe_047... | shoe_047, shoe_017, shoe_050 | shoe_007, shoe_009, shoe_018 | O | O | A:3 Cit:4 |
+| gear-07 | Responsive and court feel combination | shoe_001, shoe_002, shoe_003... | shoe_001, shoe_003, shoe_045 | shoe_005, shoe_014, shoe_043 | O | O | A:5 Cit:5 |
+| gear-08 | Stability and traction with lockdown | shoe_005, shoe_006, shoe_046 | shoe_032, shoe_017, shoe_048 | shoe_005, shoe_006, shoe_007 | X | O | A:3 Cit:4 |
+| gear-09 | Budget constraint 100K KRW | shoe_032, shoe_050 | shoe_032, shoe_050 | shoe_050, shoe_032 | O | O | A:5 Cit:5 |
+| gear-10 | Budget constraint 150K KRW with lightweight preference | shoe_016, shoe_025, shoe_026... | shoe_043, shoe_033, shoe_051 | shoe_025, shoe_026, shoe_027 | O | O | A:3 Cit:4 |
+| gear-11 | Budget constraint 200K KRW with cushioning preference | shoe_009, shoe_047, shoe_053... | shoe_059, shoe_047 | shoe_015, shoe_047, shoe_016 | O | O | A:5 Cit:5 |
+| gear-12 | Position only - guard, no player archetype | shoe_001, shoe_002, shoe_003... | shoe_057, shoe_001, shoe_006 | shoe_001, shoe_003, shoe_005 | O | O | A:5 Cit:5 |
+| gear-13 | Position only - center, no player archetype | shoe_009, shoe_015, shoe_019... | shoe_047, shoe_017, shoe_050 | shoe_007, shoe_018, shoe_047 | O | O | A:3 Cit:4 |
+| gear-14 | Complex: Damian Lillard style + guard + budget 180K | shoe_028, shoe_029 | shoe_028, shoe_029 | shoe_028, shoe_029, shoe_026 | O | O | A:5 Cit:5 |
+| gear-15 | Complex: Kyrie Irving style + guard + budget 160K + court feel | shoe_044, shoe_045 | shoe_044, shoe_045, shoe_028 | shoe_045, shoe_014, shoe_058 | O | O | A:5 Cit:5 |
+| gear-16 | Forward seeking Kawhi-style defensive lockdown with ankle support | shoe_048 | shoe_048, shoe_047, shoe_032 | shoe_048, shoe_009, shoe_015 | O | O | A:5 Cit:5 |
+| gear-17 | Forward seeking impact protection under 200K, no archetype | shoe_015, shoe_047, shoe_048... | shoe_059, shoe_047, shoe_015 | shoe_009, shoe_018, shoe_015 | O | O | A:4 Cit:5 |
+| gear-18 | Cheapest option under 80K for entry-level player | shoe_050 | shoe_050 | shoe_050, shoe_032 | O | O | A:5 Cit:5 |
+| gear-19 | Guard seeking James Harden style cushioning euro-step shoe | shoe_023, shoe_024 | shoe_024, shoe_023 | shoe_023, shoe_024, shoe_007 | O | O | A:5 Cit:5 |
+| gear-20 | Guard seeking Luka Doncic style step-back cushioning shoe | shoe_018, shoe_022 | shoe_022, shoe_018 | shoe_022, shoe_018, shoe_009 | O | O | A:5 Cit:5 |
+| gear-21 | Guard seeking Anthony Edwards style explosive responsive shoe | shoe_027 | shoe_027, shoe_001, shoe_057 | shoe_027, shoe_006, shoe_031 | O | O | A:4 Cit:5 |
+| gear-22 | Forward seeking Kevin Durant style lightweight balanced shoe | shoe_010, shoe_011, shoe_012 | shoe_010, shoe_011 | shoe_011, shoe_012, shoe_010 | O | O | A:4 Cit:5 |
+| gear-23 | Guard seeking Dwyane Wade style premium cushioning shoe | shoe_037, shoe_038 | shoe_037, shoe_038, shoe_050 | shoe_037, shoe_038, shoe_018 | O | O | A:5 Cit:5 |
+| gear-24 | Budget value pick under 150K for guard, no archetype preference | shoe_025, shoe_026, shoe_032... | shoe_051, shoe_056, shoe_049 | shoe_025, shoe_026, shoe_033 | O | O | A:3 Cit:4 |
+| gear-25 | Jayson Tatum style forward seeking all-around balanced shoe | shoe_021 | shoe_021, shoe_047, shoe_017 | shoe_021, shoe_007, shoe_018 | O | O | A:5 Cit:5 |
+
+---

--- a/docs/eval/eval_report_20260428_230907.md
+++ b/docs/eval/eval_report_20260428_230907.md
@@ -1,0 +1,23 @@
+# RAG Evaluation Report
+
+Generated: 2026-04-28 23:09:07
+
+---
+
+## Skill Lab: LLM-only vs RAG Baseline
+
+| Metric | LLM-only | RAG Baseline | Delta |
+|--------|----------|--------------|-------|
+| Equipment Pass Rate | 1.00 | 0.80 | +0.20 |
+| Time Pass Rate | 1.00 | 1.00 | +0.00 |
+| Cases | 5 | 5 | - |
+
+### Case Details
+
+| ID | Description | LLM Equip | LLM Time | RAG Equip | RAG Time |
+|----|-------------|-----------|----------|-----------|----------|
+| skill-01 | Beginner dribble drill with ball only, 15 minutes | PASS | PASS | FAIL | PASS |
+| skill-02 | Intermediate shooting drill with ball and hoop, 20 minutes | PASS | PASS | PASS | PASS |
+| skill-03 | Advanced defense drill with no equipment, 10 minutes | PASS | PASS | PASS | PASS |
+| skill-04 | Beginner conditioning drill with ball and cones, 25 minutes | PASS | PASS | PASS | PASS |
+| skill-05 | Intermediate dribble drill with full equipment, 30 minutes | PASS | PASS | PASS | PASS |


### PR DESCRIPTION
소유자 결정(포폴 PDF와 일치)에 따른 평가 기록 정리.

- 비교 가능성 확인: 4/22↔4/24 사이 scripts/eval 731줄 변경(데이터셋 기대 조문 수정 96d52de, Judge 프롬프트 분리 3539afe, 지표 재구조화 2f4abdc) → **비교 불가** → 델타 표기 없이 '재설계 후 수치'
- 리포트 8건(실패런 포함) docs/eval/ 커밋 — 키·PII 스캔 통과
- README 평가 표를 4/24(+4/28 Skill) 수치로, 각 수치에 근거 리포트 링크

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated evaluation results with redesigned retrieval and judge metrics.
  * Added links to the latest evaluation reports and expanded the evaluation history.
  * Documented current limitations, including unverified judge scores and weaker search effectiveness.
  * Added detailed reports covering gear recommendations, citation accuracy, and skill constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->