### PR TITLE
feat: LLM 엔드포인트 레이트리밋 - IP당 20회/일 + 전역 200회/일 (롤링 24h)

### DIFF
--- a/src/api/v1/router.py
+++ b/src/api/v1/router.py
@@ -1,11 +1,28 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from src.api.v1.endpoints import auth, gear, plans, skill, whistle
+from src.core.rate_limit import enforce_rate_limit
 
 api_router = APIRouter()
 
+# 레이트리밋은 LLM 호출 라우터(skill·gear·whistle)에만 적용 — auth·plans 제외
 api_router.include_router(auth.router, prefix="/auth", tags=["Auth"])
-api_router.include_router(skill.router, prefix="/skill", tags=["Skill Lab"])
-api_router.include_router(gear.router, prefix="/gear", tags=["Gear Advisor"])
-api_router.include_router(whistle.router, prefix="/whistle", tags=["The Whistle"])
+api_router.include_router(
+    skill.router,
+    prefix="/skill",
+    tags=["Skill Lab"],
+    dependencies=[Depends(enforce_rate_limit)],
+)
+api_router.include_router(
+    gear.router,
+    prefix="/gear",
+    tags=["Gear Advisor"],
+    dependencies=[Depends(enforce_rate_limit)],
+)
+api_router.include_router(
+    whistle.router,
+    prefix="/whistle",
+    tags=["The Whistle"],
+    dependencies=[Depends(enforce_rate_limit)],
+)
 api_router.include_router(plans.router, prefix="/plans", tags=["Plans"])

--- a/src/core/rate_limit.py
+++ b/src/core/rate_limit.py
@@ -1,0 +1,64 @@
+import logging
+import os
+import time
+from collections import defaultdict, deque
+
+from fastapi import HTTPException, Request
+
+logger = logging.getLogger(__name__)
+
+# 데모 생존용 최소 레이트리밋 — LLM을 실제로 호출하는 엔드포인트에만 적용.
+# 인메모리 카운터: 단일 인스턴스 전제, 재시작 시 리셋 허용.
+IP_DAILY_LIMIT = int(os.getenv("RATE_LIMIT_IP_PER_DAY", "20"))
+GLOBAL_DAILY_LIMIT = int(os.getenv("RATE_LIMIT_GLOBAL_PER_DAY", "200"))
+WINDOW_S = 24 * 3600  # 롤링 24h — '자정 리셋'이 아니라 '약 24시간 후 해제'
+
+RATE_LIMIT_MESSAGE = "오늘 요청 한도에 도달했어요. 내일 다시 시도해주세요."
+
+_ip_hits: dict[str, deque[float]] = defaultdict(deque)
+_global_hits: deque[float] = deque()
+
+
+def client_ip(request: Request) -> str:
+    # Render 프록시 뒤에서는 X-Forwarded-For의 첫 값이 실제 클라이언트 IP다.
+    fwd = request.headers.get("x-forwarded-for")
+    if fwd:
+        return fwd.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+def _prune(hits: deque[float], now: float) -> None:
+    while hits and now - hits[0] > WINDOW_S:
+        hits.popleft()
+
+
+async def enforce_rate_limit(request: Request) -> None:
+    """IP당·전역 롤링 24h 한도를 확인하고 통과 시 카운트를 소비한다.
+
+    거절된 요청은 카운트를 소비하지 않는다.
+    """
+    ip = client_ip(request)
+    now = time.time()
+    _prune(_global_hits, now)
+    hits = _ip_hits[ip]
+    _prune(hits, now)
+    if len(_global_hits) >= GLOBAL_DAILY_LIMIT or len(hits) >= IP_DAILY_LIMIT:
+        logger.warning(
+            "Rate limit exceeded: ip=%s ip_count=%d/%d global_count=%d/%d",
+            ip,
+            len(hits),
+            IP_DAILY_LIMIT,
+            len(_global_hits),
+            GLOBAL_DAILY_LIMIT,
+        )
+        raise HTTPException(status_code=429, detail=RATE_LIMIT_MESSAGE)
+    _global_hits.append(now)
+    hits.append(now)
+    logger.info(
+        "LLM request accepted: ip=%s ip_count=%d/%d global_count=%d/%d",
+        ip,
+        len(hits),
+        IP_DAILY_LIMIT,
+        len(_global_hits),
+        GLOBAL_DAILY_LIMIT,
+    )


### PR DESCRIPTION
## 왜
public 데모 + 실키 상태에서 호출 제한이 없음(코드 전수 확인 — 기존 레이트리밋 부재). 악용 1건이 키 예산을 태워 데모 전체를 죽이는 시나리오 차단. 목적은 비용이 아니라 **데모 생존**.

## 무엇
- **적용 대상 (LLM 실호출 엔드포인트만)**: `POST /api/v1/skill/` · `POST /api/v1/skill/weekly` · `POST /api/v1/gear/recommend` · `POST /api/v1/whistle/judge` — 라우터 의존성으로 주입. auth·plans·/health·/docs 미적용
- **한도**: IP당 20회/일 + 전역 200회/일, 롤링 24h. env로 조정 가능(기본값 코드 내장)
- **방식**: 인메모리 deque(jd-gap과 동일 패턴), 새 의존성 없음. 거절 요청은 카운트 미소비
- **IP**: X-Forwarded-For 첫 값(Render 프록시), 폴백 client.host. 수락/거절 모두 IP 로그 — 배포 후 실 IP 검증용
- **초과 응답**: `429 {"detail":"오늘 요청 한도에 도달했어요. 내일 다시 시도해주세요."}`

## 로컬 검증 (한도 env로 IP 3/전역 5로 낮춰 실측, 코드 원복 불필요)
- IP A 1~3회 통과(카운트 소비) → **4회째 429 + 지정 메시지** ✓
- IP B(다른 XFF)는 통과 — 첫 값 기준 IP 분리 ✓ (로그: `ip=1.2.3.4`, 두 번째 값 10.0.0.1 무시)
- 전역 5 도달 후 신규 IP C → **429 (ip_count=0/3 상태에서 발동 = 전역 한도)** ✓
- 한도 초과 상태에서 auth 요청 422(레이트리밋 미적용) ✓ · ruff check/format 통과